### PR TITLE
デフォルト型パラメーターの説明文を修正

### DIFF
--- a/features/default-type-parameter.md
+++ b/features/default-type-parameter.md
@@ -52,7 +52,7 @@ const networkErrorEvent: MyErrorEvent<NetworkError> = { error: new NetworkError(
 
 {% page-ref page="type-parameter-constraint.md" %}
 
-`MyErrorEvent`をに与えられる型`T`を`Error`のサブクラスに限定しつつ、省略時は`SyntaxError`としたい場合は次のような書き方になります。
+`MyErrorEvent`に与えられる型`T`を`Error`のサブクラスに限定しつつ、省略時は`SyntaxError`としたい場合は次のような書き方になります。
 
 ```typescript
 type MyErrorEvent<T extends Error = SyntaxError> = {


### PR DESCRIPTION
### Changelog

- デフォルト型パラメーターの `型パラメーターの制約と併用する` の説明文を修正

### URL

https://book.yyts.org/features/default-type-parameter#paramtnotosuru