### PR TITLE
コードブロックでtwoslashが使えるようにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Generated files
 .docusaurus
 .cache-loader
+/.cache
 
 # Misc
 .DS_Store

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,4 @@
 /.docusaurus
 /build
 pnpm-lock.yaml
+/.cache

--- a/docs/writing/markdown.md
+++ b/docs/writing/markdown.md
@@ -107,34 +107,26 @@ Markdownのリンクテキストは無視され、リンク先のタイトルが
 コードブロックは言語名を指定すると、シンタックスハイライトが効きます。
 
 ````markdown
-```typescript
+```ts
 // code
 ```
 ````
 
 使用可能な言語は次のとおりです。
 
-- [Prisimでデフォルトで有効になっているもの](https://github.com/FormidableLabs/prism-react-renderer/blob/master/src/vendor/prism/includeLangs.js)
-- [docusaurus.config.js](https://github.com/yytypescript/book/blob/master/docusaurus.config.js)の`additionalLanguages`で追加で有効にしたもの
-  - 必要に応じて追加できます。
-
-:::caution JSX/TSXのハイライト
-
-JSXを含むJavaScriptやTypeScriptは、`jsx`や`tsx`を用いてください。`javascript`や`typescript`ではJSX部分がうまくハイライトされません。
-
-:::
+- https://github.com/shikijs/shiki/blob/main/docs/languages.md#all-languages
 
 ### コードブロックのタイトル
 
 コードブロックにタイトルをつけるには`title`属性を指定します。
 
 ````markdown
-```typescript title="sample.ts"
+```ts title="sample.ts"
 // sample code
 ```
 ````
 
-```typescript title="sample.ts"
+```ts title="sample.ts"
 // sample code
 ```
 
@@ -142,17 +134,165 @@ JSXを含むJavaScriptやTypeScriptは、`jsx`や`tsx`を用いてください�
 
 4行以上あるコードブロックは行番号が自動で付与されます。
 
-```text
+```markdown
 1行目
 2行目
 3行目
 ```
 
-```text
+```markdown
 1行目
 2行目
 3行目
 4行目
+```
+
+### Twoslash
+
+TwoslashはサンプルコードにTypeScriptコンパイラーから得られる情報を付加する機能です。付加される情報には変数の型、コンパイルエラーのメッセージなどがあります。
+
+#### 変数の型を表示する
+
+`^?`を書くと型推論された変数の型の中身を表示できます。
+
+````markdown
+```ts twoslash
+const point = { x: 135, y: 35 };
+//    ^?
+type ReadonlyPoint = Readonly<typeof point>;
+//   ^?
+```
+````
+
+```ts twoslash title="表示例"
+const point = { x: 135, y: 35 };
+//    ^?
+type ReadonlyPoint = Readonly<typeof point>;
+//   ^?
+```
+
+#### エラーを表示する
+
+`@errors`でコンパイルエラーの内容を表示できます。
+
+````markdown
+```ts twoslash
+// @errors: 7006
+function fn(s) {}
+```
+````
+
+```ts twoslash title="表示例"
+// @errors: 7006
+function fn(s) {}
+```
+
+#### コンパイラーオプションを設定する
+
+`@コンパイラーオプション: 設定値`の形式で書くと、そのコードブロックでのみ効くコンパイラーオプションを設定できます。
+
+````markdown
+```ts twoslash
+// @noImplicitAny: false
+function fn(s) {}
+```
+````
+
+```ts twoslash title="表示例"
+// @noImplicitAny: false
+function fn(s) {}
+```
+
+#### コード補完の再現
+
+`^|`を書いたところにVS Codeでのコード補完の様子を再現できます。
+
+````markdown
+<!--prettier-ignore-->
+```ts twoslash
+// @noErrors
+[1, 2, 3].fin
+//           ^|
+```
+````
+
+<!--prettier-ignore-->
+```ts twoslash title="表示例"
+// @noErrors
+[1, 2, 3].fin
+//           ^|
+```
+
+#### JavaScriptの出力
+
+`@showEmit`でコンパイル結果のJavaScriptコードを表示できます。
+
+````markdown
+```ts twoslash title="表示例"
+// @showEmit
+enum Example {
+  FOO,
+  BAR,
+}
+```
+````
+
+```ts twoslash title="表示例"
+// @showEmit
+enum Example {
+  FOO,
+  BAR,
+}
+```
+
+#### 型定義ファイルの出力
+
+TypeScriptソースコードを型定義ファイルに変換した結果を表示できます。
+
+````markdown
+```ts twoslash
+// @declaration: true
+// @showEmit
+// @showEmittedFile: index.d.ts
+
+export function getStringLength(value: string) {
+  return value.length;
+}
+```
+````
+
+```ts twoslash title="表示例"
+// @declaration: true
+// @showEmit
+// @showEmittedFile: index.d.ts
+
+export function getStringLength(value: string) {
+  return value.length;
+}
+```
+
+#### インラインハイライト(下線)
+
+下線`^^`を引いた部分がハイライトされます。これは未対応で、下線コメントが消えるだけです。
+
+````markdown
+```ts twoslash
+function greet(person: string, date: Date) {
+  console.log(`Hello ${person}, today is ${date.toDateString()}!`);
+}
+
+greet("Maddison", new Date());
+//                ^^^^^^^^^^
+```
+````
+
+```ts twoslash title="表示例"
+function greet(person: string, date: Date) {
+  console.log(`Hello ${person}, today is ${date.toDateString()}!`);
+}
+
+greet("Maddison", new Date());
+//                ^^^^^^^^^^
 ```
 
 ### 行ハイライト
@@ -160,7 +300,7 @@ JSXを含むJavaScriptやTypeScriptは、`jsx`や`tsx`を用いてください�
 特定の行に注目してもらいたいときは、行番号を書くとその行の背景色を変えられます。
 
 ````markdown
-```jsx {1,4-6,11} title="行ハイライトの表示例"
+```js twoslash {1,4-6,11} title="行ハイライトの表示例"
 import React from "react";
 
 function MyComponent(props) {
@@ -175,7 +315,7 @@ export default MyComponent;
 ```
 ````
 
-```jsx {1,4-6,11} title="行ハイライトの表示例"
+```js twoslash {1,4-6,11} title="行ハイライトの表示例"
 import React from "react";
 
 function MyComponent(props) {
@@ -195,24 +335,24 @@ export default MyComponent;
 
 自動整形をされたくないコードブロック場合は、`<!--prettier-ignore-->`を直前に書きます。
 
-````markdown {5}
-```typescript
+````markdown {4}
+```ts
 f = x => x;
 ```
 
 <!--prettier-ignore-->
-```typescript
+```ts
 f = x => x;
 ```
 ````
 
-````markdown {2,7} title="整形結果"
-```typescript
+````markdown {1,6} title="整形結果"
+```ts
 f = (x) => x;
 ```
 
 <!--prettier-ignore-->
-```typescript
+```ts
 f = x => x;
 ```
 ````

--- a/docs/writing/vscode.md
+++ b/docs/writing/vscode.md
@@ -16,3 +16,7 @@ VS Codeでは次のショートカットキーでMarkdownプレビューが表�
 ## markdownlintプラグイン
 
 [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)プラグインをインストールすると、修正が必要な箇所がわかりやすくなります。
+
+## twoslashプラグイン
+
+[twoslashプラグイン](https://marketplace.visualstudio.com/items?itemName=Orta.vscode-twoslash)をインストールすると、twoslashの補完が効くようになります。

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -42,6 +42,10 @@ const { tweetILearned } = require("./src/remark/tweetILearned");
           },
         }),
       ],
+      [
+        "docusaurus-preset-shiki-twoslash",
+        { themes: ["min-light", "min-dark"] },
+      ],
     ],
 
     themeConfig:

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",
+    "docusaurus-preset-shiki-twoslash": "^1.1.32",
     "file-loader": "^6.2.0",
     "prism-react-renderer": "^1.2.1",
     "react": "^17.0.1",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -97,3 +97,70 @@ html[data-theme="dark"] .docusaurus-highlight-code-line {
 .prism-code .token-line:first-child:nth-last-child(3) ~ .token-line::before {
   display: none;
 }
+
+code {
+  counter-reset: step;
+  counter-increment: step 0;
+}
+
+code .line::before {
+  content: counter(step);
+  counter-increment: step;
+  width: 1rem;
+  margin-right: 1rem;
+  display: inline-block;
+  text-align: right;
+  font-size: 0.85rem;
+  color: rgba(115, 138, 148, 0.4);
+}
+
+code .meta-line::before {
+  content: "";
+  width: 1rem;
+  margin-right: 1rem;
+  display: inline-block;
+}
+
+/* 3行以内のコードブロックは行番号を表示しないスタイル */
+code .line:only-child::before,
+code .line:first-child:nth-last-child(2)::before,
+code .line:first-child:nth-last-child(2) ~ .line::before,
+code .line:first-child:nth-last-child(2) ~ .meta-line::before,
+code .line:first-child:nth-last-child(3)::before,
+code .line:first-child:nth-last-child(3) ~ .line::before,
+code .line:first-child:nth-last-child(3) ~ .meta-line::before {
+  display: none;
+}
+
+[data-theme="light"] .shiki.min-dark {
+  display: none;
+}
+
+[data-theme="dark"] .shiki.min-light {
+  display: none;
+}
+
+pre .popover,
+pre .error,
+pre .error-behind,
+pre .inline-completions {
+  font-size: 0.85rem;
+}
+
+pre .error {
+  background-color: var(--ifm-color-danger-contrast-background) !important;
+  color: var(--ifm-font-color-base) !important;
+}
+
+pre .inline-completions ul.dropdown {
+  width: auto !important;
+}
+
+pre .inline-completions ul.dropdown li {
+  margin-right: 1rem;
+}
+
+pre code {
+  word-wrap: normal;
+  white-space: nowrap;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2165,6 +2165,22 @@
     anymatch "^3.0.0"
     source-map "^0.6.0"
 
+"@typescript/twoslash@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@typescript/twoslash/-/twoslash-2.2.0.tgz#176317e6bfeae2ebb8a5dd37dbf735096c4462e4"
+  integrity sha512-Lkgrs9L/OIn1JZcIv2k4uy/CsQ+9dmurN64YzSWIHleTE3PkZlV2lZdq9xM7TnLh5zFy3tP8KuPtUxbIGV9sIw==
+  dependencies:
+    "@typescript/vfs" "1.3.4"
+    debug "^4.1.1"
+    lz-string "^1.4.4"
+
+"@typescript/vfs@1.3.4":
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/@typescript/vfs/-/vfs-1.3.4.tgz#07f89d2114f6e29255d589395ed7f3b4af8a00c2"
+  integrity sha512-RbyJiaAGQPIcAGWFa3jAXSuAexU4BFiDRF1g3hy7LmRqfNpYlTQWGXjcrOaVZjJ8YkkpuwG0FcsYvtWQpd9igQ==
+  dependencies:
+    debug "^4.1.1"
+
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.1.tgz#2bfd767eae1a6996f432ff7e8d7fc75679c0b6a7"
@@ -3803,6 +3819,15 @@ dns-txt@^2.0.2:
   dependencies:
     buffer-indexof "^1.0.0"
 
+docusaurus-preset-shiki-twoslash@^1.1.32:
+  version "1.1.32"
+  resolved "https://registry.yarnpkg.com/docusaurus-preset-shiki-twoslash/-/docusaurus-preset-shiki-twoslash-1.1.32.tgz#61591001beeba8fe59fff7e0cee79e3de3df49de"
+  integrity sha512-BACiGWKMhcsrFrl1Gojz0NIgp++RJRKIGrWEI2AeqIzrtYTFRIo8jWNhqtajf6jV2JQIUmyUz/Ozyz/nu5v38w==
+  dependencies:
+    copy-text-to-clipboard "^3.0.1"
+    remark-shiki-twoslash "3.0.5"
+    typescript ">3"
+
 dom-converter@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.2.0.tgz#6721a9daee2e293682955b6afe416771627bb768"
@@ -4328,6 +4353,11 @@ feed@^4.2.2:
   integrity sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==
   dependencies:
     xml-js "^1.6.11"
+
+fenceparser@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/fenceparser/-/fenceparser-1.1.1.tgz#e10a5f12a54884d4f14edb0f7a52a0edc58fa667"
+  integrity sha512-VdkTsK7GWLT0VWMK5S5WTAPn61wJ98WPFwJiRHumhg4ESNUO/tnkU8bzzzc62o6Uk1SVhuZFLnakmDA4SGV7wA==
 
 figures@^3.2.0:
   version "3.2.0"
@@ -5762,7 +5792,7 @@ json5@^2.1.1, json5@^2.1.2:
   dependencies:
     minimist "^1.2.5"
 
-jsonc-parser@~3.0.0:
+jsonc-parser@^3.0.0, jsonc-parser@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.0.0.tgz#abdd785701c7e7eaca8a9ec8cf070ca51a745a22"
   integrity sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==
@@ -6079,6 +6109,13 @@ lowercase-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
   integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
 
+lru-cache@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
+  dependencies:
+    yallist "^3.0.2"
+
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
@@ -6095,6 +6132,11 @@ lunr@^2.3.9:
   version "2.3.9"
   resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.9.tgz#18b123142832337dd6e964df1a5a7707b25d35e1"
   integrity sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==
+
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
 
 make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   version "3.1.0"
@@ -6850,6 +6892,13 @@ onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+onigasm@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/onigasm/-/onigasm-2.2.5.tgz#cc4d2a79a0fa0b64caec1f4c7ea367585a676892"
+  integrity sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==
+  dependencies:
+    lru-cache "^5.1.1"
 
 open@^7.0.2:
   version "7.4.2"
@@ -8028,7 +8077,7 @@ regenerate@^1.4.2:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
-regenerator-runtime@^0.13.4:
+regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
   integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
@@ -8204,6 +8253,21 @@ remark-parse@^9.0.0:
   integrity sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==
   dependencies:
     mdast-util-from-markdown "^0.8.0"
+
+remark-shiki-twoslash@3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/remark-shiki-twoslash/-/remark-shiki-twoslash-3.0.5.tgz#2bb1854f2995b3206345eabd7125ced7218d70bf"
+  integrity sha512-7asnFLAZtJ7XiDsxJRGKdZNvD+q00je2VIR1wSDhXbODlYMiyw+llWyqFaLhk96Iag+ppmnxcoFtJyIxcJ8WFA==
+  dependencies:
+    "@typescript/twoslash" "2.2.0"
+    "@typescript/vfs" "1.3.4"
+    fenceparser "^1.1.0"
+    regenerator-runtime "^0.13.7"
+    shiki "0.9.11"
+    shiki-twoslash "3.0.1"
+    tslib "2.1.0"
+    typescript ">3"
+    unist-util-visit "^2.0.0"
 
 remark-squeeze-paragraphs@4.0.0:
   version "4.0.0"
@@ -8629,6 +8693,33 @@ shelljs@^0.8.4:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
+
+shiki-twoslash@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/shiki-twoslash/-/shiki-twoslash-3.0.1.tgz#a9f305692ba5e8ab29a3e40ec49530a9439171d1"
+  integrity sha512-gm2qyyu7iqmVn3wnKOg4DG6DodyDEh/e4Yo5SqyOBbgzM/qAP0q6LvcaG32q/lTQRBwfS3GhwvvzkQT1RxNC6Q==
+  dependencies:
+    "@typescript/twoslash" "2.2.0"
+    "@typescript/vfs" "1.3.4"
+    shiki "0.9.3"
+    typescript ">3"
+
+shiki@0.9.11:
+  version "0.9.11"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.9.11.tgz#07d75dab2abb6dc12a01f79a397cb1c391fa22d8"
+  integrity sha512-tjruNTLFhU0hruCPoJP0y+B9LKOmcqUhTpxn7pcJB3fa+04gFChuEmxmrUfOJ7ZO6Jd+HwMnDHgY3lv3Tqonuw==
+  dependencies:
+    jsonc-parser "^3.0.0"
+    onigasm "^2.2.5"
+    vscode-textmate "5.2.0"
+
+shiki@0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.9.3.tgz#7bf7bcf3ed50ca525ec89cc09254abce4264d5ca"
+  integrity sha512-NEjg1mVbAUrzRv2eIcUt3TG7X9svX7l3n3F5/3OdFq+/BxUdmBOeKGiH4icZJBLHy354Shnj6sfBTemea2e7XA==
+  dependencies:
+    onigasm "^2.2.5"
+    vscode-textmate "^5.2.0"
 
 side-channel@^1.0.4:
   version "1.0.4"
@@ -9324,6 +9415,11 @@ ts-essentials@^2.0.3:
   resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-2.0.12.tgz#c9303f3d74f75fa7528c3d49b80e089ab09d8745"
   integrity sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==
 
+tslib@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
+  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+
 tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -9366,7 +9462,7 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.4.3:
+typescript@>3, typescript@^4.4.3:
   version "4.4.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
   integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
@@ -9763,6 +9859,16 @@ vfile@^4.0.0:
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
 
+vscode-textmate@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-5.2.0.tgz#01f01760a391e8222fe4f33fbccbd1ad71aed74e"
+  integrity sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==
+
+vscode-textmate@^5.2.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-5.4.0.tgz#4b25ffc1f14ac3a90faf9a388c67a01d24257cd7"
+  integrity sha512-c0Q4zYZkcLizeYJ3hNyaVUM2AA8KDhNCA3JvXY8CeZSJuBdAy3bAvSbv46RClC4P3dSO9BdwhnKEx2zOo6vP/w==
+
 wait-on@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-5.3.0.tgz#584e17d4b3fe7b46ac2b9f8e5e102c005c2776c7"
@@ -10078,6 +10184,11 @@ y18n@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
   integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
+
+yallist@^3.0.2:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
+  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
TypeScript公式ドキュメントでも使われているtwoslashを導入します。

# できるようになること

- サンプルコードがtscで静的チェックされ、サンプルコードのエラー有無がわかります。
- サンプルコードの変数にカーソルを乗せると、VS CodeやTypeScript Playgroundのように型推論の内容がポップオーバーで表示されます。
- コンパイルエラーメッセージをサンプルコードにインラインで表示できます。
- 型推論の内容をサンプルコードにインラインで表示できます。
- コンパイル結果のJavaScriptや型定義ファイルの内容を表示できます。
- エディタでのコード補完の様子をサンプルコードで再現できます。
- サンプルコードごとにコンパイラオプションの指定ができます。

# 執筆にあたってのメリット

- サンプルコードが静的チェックされるので、少なくともコンパイルに通ることが保証されます。
- コンパイルエラーメッセージを例示するとき、コンパイルエラーを起こしてみてメッセージをコピペするといった作業が不要になります。
- コンパイルエラーメッセージはtwoslashが自動生成するので、コピペミスなどが起きなくなります。
- 型推論結果の例示がしやすくなります。

# デモページ

https://book-git-twoslash-yytypescript.vercel.app/writing/markdown#twoslash

# 詳細

![CleanShot 2021-10-26 at 05 34 02@2x](https://user-images.githubusercontent.com/855338/138767345-7465b030-c990-4ae1-95b7-ad0aa57fd33f.png)

![CleanShot 2021-10-26 at 05 36 40](https://user-images.githubusercontent.com/855338/138767712-0c283e88-2a9f-4fc5-b5dd-a136f809cd9e.gif)

# 副作用

- 今までシンタックスハイライトはPrism.jsでしたが、twoslashを導入するとShikiになります。そのため対応している言語が少なくなります。本書で扱う言語としては十分なので問題はないと思います。
- Shikiになるため、コードブロックの言語名が指すものが変わります。例えば、Prismではzshとbashは別でしたが、Shikiではsh、bash、zshは同じになります。
- Shikiになるため、コードブロックの言語名が異なる可能性があります。
- TypeScriptコードはコンパイラにかけられるため、Docusaurusの開発サーバーの初回起動が遅くなります。