### PR TITLE
誤字を修正

### DIFF
--- a/docs/overview/before-typescript.md
+++ b/docs/overview/before-typescript.md
@@ -24,7 +24,7 @@ JavaScript誕生以前は、簡単なフォームのバリデーションをす�
 
 ### くすぶりはじめる大規模開発のニーズ
 
-他のプラットフォームに目を移すと、この時期はすでにブラウザアプリケーションを実現する技術として、[Javaアプレット](https://ja.wikipedia.org/wiki/Java%E3%82%A2%E3%83%97%E3%83%AC%E3%83%83%E3%83%88)や[Adobe Flash](https://ja.wikipedia.org/wiki/Adobe_Flash)がありました。特にFlashはJavaアプレットよりも動作が軽く、ウェブサイト全体をFlashで実装するサイトが登場したり、この時代を省みて「[Flash黄金時代](https://dic.nicovideo.jp/a/flash%E9%BB%84%E9%87%91%E6%99%82%E4%BB%A3)」という言葉が後に生まれたりしました。一方のJavaScriptは依然として「補助的な道具」のイメージが支配的でした。
+他のプラットフォームに目を移すと、この時期はすでにブラウザアプリケーションを実現する技術として、[Javaアプレット](https://ja.wikipedia.org/wiki/Java%E3%82%A2%E3%83%97%E3%83%AC%E3%83%83%E3%83%88)や[Adobe Flash](https://ja.wikipedia.org/wiki/Adobe_Flash)がありました。特にFlashはJavaアプレットよりも動作が軽く、ウェブサイト全体をFlashで実装するサイトなどが登場しました。この時代を指して「[Flash黄金時代](https://dic.nicovideo.jp/a/flash%E9%BB%84%E9%87%91%E6%99%82%E4%BB%A3)」と表現することがあります。一方のJavaScriptは依然として「補助的な道具」のイメージが支配的でした。
 
 一般的に対話型のユーザーインターフェースを備えたウェブサイト、今で言うウェブアプリケーションは、当時は「リッチインターネットアプリケーション」と呼ばれ、その多くはJavaアプレットやFlashが担っていましたが、プログラマの中にはJavaScriptを使ったウェブアプリケーションの開発を試みる人たちもいました。
 

--- a/docs/overview/before-typescript.md
+++ b/docs/overview/before-typescript.md
@@ -24,7 +24,7 @@ JavaScript誕生以前は、簡単なフォームのバリデーションをす�
 
 ### くすぶりはじめる大規模開発のニーズ
 
-他のプラットフォームに目を移すと、このとき期にはすでにブラウザアプリケーションを実現する技術として、[Javaアプレット](https://ja.wikipedia.org/wiki/Java%E3%82%A2%E3%83%97%E3%83%AC%E3%83%83%E3%83%88)や[Adobe Flash](https://ja.wikipedia.org/wiki/Adobe_Flash)がありました。特にFlashはJavaアプレットよりも動作が軽く、ウェブサイト全体をFlashで実装するサイトが登場したり、この時代を省みて「[Flash黄金時代](https://dic.nicovideo.jp/a/flash%E9%BB%84%E9%87%91%E6%99%82%E4%BB%A3)」という言葉が後に生まれたりしました。一方のJavaScriptは依然として「補助的な道具」のイメージが支配的でした。
+他のプラットフォームに目を移すと、この時期はすでにブラウザアプリケーションを実現する技術として、[Javaアプレット](https://ja.wikipedia.org/wiki/Java%E3%82%A2%E3%83%97%E3%83%AC%E3%83%83%E3%83%88)や[Adobe Flash](https://ja.wikipedia.org/wiki/Adobe_Flash)がありました。特にFlashはJavaアプレットよりも動作が軽く、ウェブサイト全体をFlashで実装するサイトが登場したり、この時代を省みて「[Flash黄金時代](https://dic.nicovideo.jp/a/flash%E9%BB%84%E9%87%91%E6%99%82%E4%BB%A3)」という言葉が後に生まれたりしました。一方のJavaScriptは依然として「補助的な道具」のイメージが支配的でした。
 
 一般的に対話型のユーザーインターフェースを備えたウェブサイト、今で言うウェブアプリケーションは、当時は「リッチインターネットアプリケーション」と呼ばれ、その多くはJavaアプレットやFlashが担っていましたが、プログラマの中にはJavaScriptを使ったウェブアプリケーションの開発を試みる人たちもいました。
 


### PR DESCRIPTION
## 誤字の修正
[docs/overview/before-typescript.md](https://github.com/yytypescript/book/blob/334b42108fa3f6c852f578eaa4850c6d2fbd2664/docs/overview/before-typescript.md)
27行目に変換ミスと思われる誤字があったので修正。

## 文の表現を変更
同じファイルの27行目です。
前の過去文に続き、たびたび過去形の文で終わっているのは( _個人的に_ )やや奇妙な感じがします。誤字を修正した部分の近くに現在形で表せそうな箇所があったので、過去に対する表現を変えてみた次第です。

(実用関係なくて気にしすぎな気はする)