### PR TITLE
kyeof => keyof に修正

### DIFF
--- a/docs/tips/generates-type-from-object-key.md
+++ b/docs/tips/generates-type-from-object-key.md
@@ -44,7 +44,7 @@ type TypeOfLanguage = typeof conf;
 
 ### `keyof`
 
-`kyeof`はオブジェクトの型に使うとそのオブジェクトのキーをユニオン型にして返します。上記の`TypeOfLanguage`型があれば
+`keyof`はオブジェクトの型に使うとそのオブジェクトのキーをユニオン型にして返します。上記の`TypeOfLanguage`型があれば
 
 ```typescript
 type Langauge = keyof TypeOfLanguage;


### PR DESCRIPTION
typo( `kyeof` )を発見したので修正しました。
ご確認よろしくお願いします。