### PR TITLE
脱字の修正

### DIFF
--- a/docs/tutorials/react-like-button-tutorial.md
+++ b/docs/tutorials/react-like-button-tutorial.md
@@ -337,4 +337,4 @@ function LikeButton() {
 
 ![](react-like-button-tutorial/like2.gif)
 
-以上でTypeScript作るReactいいねボタンは完成です。
+以上でTypeScriptで作るReactいいねボタンは完成です。


### PR DESCRIPTION
「TypeScript作る」→「TypeScript`で`作る」

脱字と思われるので修正のPRです。