### PR TITLE
「配列の破壊的操作」ページのサンプルプログラムの修正

### DIFF
--- a/docs/reference/values-types-variables/array/array-operations.md
+++ b/docs/reference/values-types-variables/array/array-operations.md
@@ -46,7 +46,7 @@ const last = (arr: string[]) => {
 
 const fruits = ["apple", "banana", "orange"];
 const lastItem = last(fruits);
-const firstItem = last(fruits);
+const firstItem = fruits[0];
 
 console.log(lastItem); // orange
 console.log(firstItem); // orange


### PR DESCRIPTION
[破壊的操作の危険性](https://book.yyts.org/reference/values-types-variables/array/array-operations#%E7%A0%B4%E5%A3%8A%E7%9A%84%E6%93%8D%E4%BD%9C%E3%81%AE%E5%8D%B1%E9%99%BA%E6%80%A7) の文章では先頭の要素を取得とあるが、サンプルプログラムでは末尾の要素を取得していたので修正しました。