### PR TITLE
「記号とキーワード」の`||`論理和の説明と例を修正

### DIFF
--- a/docs/symbols-and-keywords.md
+++ b/docs/symbols-and-keywords.md
@@ -843,11 +843,27 @@ const id3 = true; // ERROR
 
 ### `||` 論理和 (logical or) ![js]
 
-ひとつでも真偽値が`true`のときに`true`を返します。そうでない場合に`false`を返します。
+左の値がtruthyな場合はそれを返します。そうでないときは右の値を返します。
+
+特にboolean値の場合は、ひとつでも`true`のときに`true`を返し、そうでない場合に`false`を返します。
+
+```javascript
+console.log(true || false) // true
+console.log(false || false) // false
+
+console.log(false || 'abc') // 'abc'
+```
 
 ### `||=` 論理和代入 (logical or assignment) ![js]
 
-左の変数の真偽値と右の真偽値の論理和の結果を左の変数に割り当てます。
+左の変数と右の値の`||`論理和の結果を左の変数に割り当てます。
+
+```javascript
+let a = false;
+let b = 1;
+a ||= b;
+console.log(a); // 1
+```
 
 ### `~` ビット否定演算子 (bitwise not) ![js]
 


### PR DESCRIPTION
論理和の説明をより正確にし、それに合わせ例も追加修正しました。