### PR TITLE
twoslashのデフォルトコンパイラオプションを変更しました。

### DIFF
--- a/docs/writing/markdown.md
+++ b/docs/writing/markdown.md
@@ -203,6 +203,12 @@ function fn(s) {}
 function fn(s) {}
 ```
 
+:::tip
+
+twoslashのデフォルトのコンパイラオプションはtsconfig.twoslash.jsonをご覧ください。
+
+:::
+
 #### 実行結果を表示する
 
 `@log`、`@warn`、`@error`を用いると、実行結果のコメントをスタイリングして表示できます。

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -44,7 +44,12 @@ const { tweetILearned } = require("./src/remark/tweetILearned");
       ],
       [
         "docusaurus-preset-shiki-twoslash",
-        { themes: ["min-light", "min-dark"] },
+        {
+          themes: ["min-light", "min-dark"],
+          defaultCompilerOptions: {
+            project: __dirname + "/tsconfig.twoslash.json",
+          },
+        },
       ],
     ],
 

--- a/tsconfig.twoslash.json
+++ b/tsconfig.twoslash.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "es2016",
+    "allowJs": true,
+    "strict": true,
+    "types": ["node"]
+  }
+}


### PR DESCRIPTION
- デフォルトコンパイラオプションtsconfig.twoslash.jsonになります。
- デフォルトで`types: ["node"]`が有効になりました。`require`がサンプルコードで使えます。