### PR TITLE
feat: 🎸 huskyのgit hookがyarn install時に有効化するようになりました。

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "preinstall": "npx only-allow yarn",
     "markdownlint": "markdownlint '**/*.md'",
     "markdownlint:fix": "yarn markdownlint --fix",
+    "prepare": "husky install",
     "prettier": "prettier '**/*.{js,jsx,ts,tsx,json,json5,css,scss,graphql,gql,html,vue,yaml,md}' --check",
     "prettier:fix": "yarn prettier --write",
     "serve": "docusaurus serve",
@@ -24,6 +25,15 @@
     "typecheck": "tsc",
     "write-heading-ids": "docusaurus write-heading-ids",
     "write-translations": "docusaurus write-translations"
+  },
+  "lint-staged": {
+    "*.md": [
+      "markdownlint --fix",
+      "prettier --write",
+      "markdownlint",
+      "textlint"
+    ],
+    "*.{js,jsx,ts,tsx,json,json5,css,scss,graphql,gql,html,vue,yaml}": "prettier --write"
   },
   "browserslist": {
     "production": [
@@ -36,15 +46,6 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "lint-staged": {
-    "*.md": [
-      "markdownlint --fix",
-      "prettier --write",
-      "markdownlint",
-      "textlint"
-    ],
-    "*.{js,jsx,ts,tsx,json,json5,css,scss,graphql,gql,html,vue,yaml}": "prettier --write"
   },
   "dependencies": {
     "@cmfcmf/docusaurus-search-local": "^0.9.0",


### PR DESCRIPTION
#187 でコミット時にリントが実行される機構が追加されましたが、git hookへの登録が手動だったため、これを自動化するようにしました。

このPRよりも以前から開発環境を持っている方は、一度手動でgit hookへの登録が必要です。これを行うには`yarn`を実行してください。`yarn`の実行結果に「Git hooks installed」が表示されれば成功です。

![20211212_095859](https://user-images.githubusercontent.com/855338/145696628-6fdb954a-17c1-4ae2-8048-0419ae526bca.png)

