### PR TITLE
docs: :pencil2: Map と　Set のシャローコピーを簡略化

### DIFF
--- a/docs/tips/shallow-copy-object.md
+++ b/docs/tips/shallow-copy-object.md
@@ -285,10 +285,10 @@ const m1: Map<number, string> = new Map<number, string>([
   [2, "e"],
   [3, "f"],
 ]);
-const m2 = new Map([...m1]);
+const m2 = new Map(m1);
 
 const s1: Set<string> = new Set(["g", "d", "k"]);
-const s2: Set<string> = new Set([...s1]);
+const s2: Set<string> = new Set(s1);
 ```
 
 2, 9, 16 行目がそれぞれのコレクションの浅いコピーを意味しています。


### PR DESCRIPTION
https://stackoverflow.com/questions/30626070/shallow-clone-a-map-or-set

```
var clonedMap = new Map(originalMap)
var clonedSet = new Set(originalSet)
```

ここにあるように、 `Set` と `Map` をシャローコピーするために、コンストラクタに直接`Set`や`Map`を渡すのが好ましいと思われるのですが、いかがでしょうか。
