### PR TITLE
誤字「@log: 1 2」を「@log: 0 0」に修正しました。

### DIFF
--- a/docs/reference/functions/destructuring-assignment-parameters.md
+++ b/docs/reference/functions/destructuring-assignment-parameters.md
@@ -149,7 +149,7 @@ function foo({ a, b } = { a: 0, b: 0 }) {
   console.log(a, b);
 }
 foo();
-// @log: 1 2
+// @log: 0 0
 foo({ a: 1 });
 // @log: 1 undefined
 
@@ -157,7 +157,7 @@ function bar([a, b] = [0, 0]) {
   console.log(a, b);
 }
 bar();
-// @log: 1 2
+// @log: 0 0
 bar([1]);
 // @log: 1 undefined
 ```


### PR DESCRIPTION
記載されている関数の実行結果が間違っているように思います。
ドキュメントの関数定義と呼び出しは以下ですが、
```js
function foo({ a, b } = {a: 0, b: 0}) {
  console.log(a, b);
}
foo();
foo({ a: 1 });

function bar([a, b] = [0, 0]) {
  console.log(a, b);
}
bar();
bar([1]);
```
実行結果は手元では以下のようになりました。
```bash
$ node test.js
0 0
1 undefined
0 0
1 undefined
```
コード的にも 0 0 が正しいかと思います。