### PR TITLE
chore: 🤖 Yarnのバージョン指定を1.22.17に明確化しました。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,11 @@ yarn-error.log*
 
 # JetBrains IDE
 /.idea
+
+# yarn
+/.yarn/*
+!/.yarn/patches
+!/.yarn/plugins
+!/.yarn/releases
+!/.yarn/sdks
+/.pnp.*

--- a/.yarn/.gitattributes
+++ b/.yarn/.gitattributes
@@ -1,0 +1,3 @@
+# To prevent showing massive diffs when each time you subsequently add or update them
+/releases/** binary
+/plugins/** binary

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+yarnPath: .yarn/releases/yarn-1.22.17.cjs

--- a/package.json
+++ b/package.json
@@ -82,6 +82,8 @@
     "ts-jest": "^27.1.2"
   },
   "engines": {
-    "node": ">=14.x"
-  }
+    "node": ">=14.x",
+    "yarn": "^1.22.17"
+  },
+  "packageManager": "yarn@1.22.17"
 }


### PR DESCRIPTION
CorepackやデフォルトでYarn v3系を使っている開発者への配慮です。

CorepackやYarn v2以降を使っている場合、自動的に1.22.17が起動するようになります。
