### PR TITLE
複数の誤植修正

### DIFF
--- a/docs/overview/before-typescript.md
+++ b/docs/overview/before-typescript.md
@@ -133,7 +133,7 @@ TypeScriptの発表後、JavaScriptも再び進歩を始め、6年ぶりのメ�
 - [ActionScript - Wikipedia](https://en.wikipedia.org/wiki/ActionScript)
 - [JavaScript - Wikipedia](https://ja.wikipedia.org/wiki/JavaScript)
 - [ECMAScript - Wikipedia](https://en.wikipedia.org/wiki/ECMAScript)
-- [A Brief History of JavaScrip](https://auth0.com/blog/a-brief-history-of-javascript/)
+- [A Brief History of JavaScript](https://auth0.com/blog/a-brief-history-of-javascript/)
 - [The ECMAScript 6 schedule change](https://2ality.com/2014/06/es6-schedule.html#fn2)
 - [見えてきた「ECMAScript 6」。JavaScriptの生みの親が書く「Harmony of Dreams Come True」 － Publickey](https://www.publickey1.jp/blog/12/javascriptecmascript_6harmony_of_dreams_come_true.html)
 - [JavaScript: The First 20 Years | Zenod](https://zenodo.org/record/3707008#.XrVIhBMzZTY)

--- a/docs/reference/functions/function-expression-vs-arrow-functions.md
+++ b/docs/reference/functions/function-expression-vs-arrow-functions.md
@@ -455,7 +455,7 @@ console.log(taroYamada.fullName2());
 // @log: undefined undefined
 ```
 
-アロー関数を用いた`fullName2`deは`this`がオブジェクトを指さないため、期待どおりの動作になりません。もし、アロー関数を使う場合は、`this`ではなく`taroYamada.firstName`のようにオブジェクトの変数名を参照する必要があります。
+アロー関数を用いた`fullName2`は`this`がオブジェクトを指さないため、期待どおりの動作になりません。もし、アロー関数を使う場合は、`this`ではなく`taroYamada.firstName`のようにオブジェクトの変数名を参照する必要があります。
 
 ```js twoslash
 const taroYamada = {

--- a/docs/reference/statements/exception.md
+++ b/docs/reference/statements/exception.md
@@ -7,11 +7,10 @@ sidebar_label: 例外処理
 JavaScriptにはJavaに似た例外処理の構文があります。例外には`Error`オブジェクトを使い、throw構文で例外を投げます。try-catch構文で例外を捕捉できます。
 
 ```js twoslash
-// prettier-ignore
 try {
   throw new Error("something wrong");
 } catch (e) {
-// something wrong
+  // something wrong
   console.log(e.message);
 }
 ```

--- a/docs/reference/statements/if-else.md
+++ b/docs/reference/statements/if-else.md
@@ -29,7 +29,7 @@ JavaScriptのif-elseは文です。式ではないので、条件分岐を直接
 const result = if (value === 0) "OK" else "NG";
 ```
 
-式で条件分岐使いたい場合は三項演算子(ternary operator)を用います。
+式で条件分岐を使いたい場合は三項演算子(ternary operator)を用います。
 
 ```js twoslash
 const result = value === 0 ? "OK" : "NG";

--- a/docs/reference/values-types-variables/object/how-to-loop-an-object.md
+++ b/docs/reference/values-types-variables/object/how-to-loop-an-object.md
@@ -115,8 +115,8 @@ for-in文と異なり、`hasOwnProperty`のチェックが不要です。
 ```ts twoslash
 // @target: es2017
 const foo = { a: 1, b: 2, c: 3 };
-for (const key of Object.values(foo)) {
-  console.log(key);
+for (const value of Object.values(foo)) {
+  console.log(value);
   // 1
   // 2
   // 3 の順で出力される


### PR DESCRIPTION
- docs: 📚 誤字「JavaScrip」→「JavaScrip`t`」
- docs: 📚 誤字「key」→「value」
- docs: 📚 誤字「条件分岐使いたい」→「条件分岐`を`使いたい」
- docs: 📚 サンプルコードのインデントずれを修正しました。
- docs: 📚 誤字:「用いたfullName2`de`は」→「用いたfullName2は」

Close #416