### PR TITLE
interfaceでの宣言と、type aliasによる宣言の違いの同名定義セクション

### DIFF
--- a/docs/reference/object-oriented/interface/interface-vs-type-alias.md
+++ b/docs/reference/object-oriented/interface/interface-vs-type-alias.md
@@ -147,7 +147,38 @@ type Dog = {
 
 ### 同名のものを宣言
 
-TODO: 書く
+型エイリアスは同名のものを複数定義できず、コンパイルエラーになります。
+
+```ts twoslash
+// @errors: 2300
+type SameNameTypeWillError = {
+  message: string;
+};
+type SameNameTypeWillError = {
+  detail: string;
+};
+```
+
+一方、インターフェースの場合は、同名のインターフェースを定義でき、同名の定義をすべて合成したインターフェースになります。
+ただし、同名のフィールドだが、型の定義が違っている場合はコンパイルエラーになります。
+
+```ts twoslash
+// @errors: 2717
+interface SameNameInterfaceIsAllowed {
+  myField: string;
+  sameNameSameTypeIsAllowed: number;
+  sameNameDifferentTypeIsNotAllowed: string;
+}
+
+interface SameNameInterfaceIsAllowed {
+  newField: string;
+  sameNameSameTypeIsAllowed: number;
+}
+
+interface SameNameInterfaceIsAllowed {
+  sameNameDifferentTypeIsNotAllowed: number;
+}
+```
 
 ### Mapped Type
 


### PR DESCRIPTION
`interfaceでの宣言と、type aliasによる宣言の違い`の`同名のものを宣言`セクションを書きました。