### PR TITLE
docs: 📚 誤植「再起」→「再帰」

### DIFF
--- a/docs/reference/functions/function-expression.md
+++ b/docs/reference/functions/function-expression.md
@@ -142,7 +142,7 @@ const factorial = function fact(n) {
 };
 ```
 
-上の例は、次のように変数名を使った再起呼び出しに書き換えることもできます。
+上の例は、次のように変数名を使った再帰呼び出しに書き換えることもできます。
 
 ```js {6} twoslash
 //                        ↓関数名を省略
@@ -150,7 +150,7 @@ const factorial = function (n) {
   if (n <= 1) {
     return 1;
   }
-  return n * factorial(n - 1); // 変数名を使った再起呼び出し
+  return n * factorial(n - 1); // 変数名を使った再帰呼び出し
 };
 ```
 

--- a/prh/yytypescript.yml
+++ b/prh/yytypescript.yml
@@ -31,3 +31,5 @@ rules:
     patterns: /[pP]olyfill/
   - expected: 巻き上げ
     patterns: 巻上げ
+  - expected: 再帰呼び出し
+    patterns: 再起呼び出し


### PR DESCRIPTION
Closes: #467
