### PR TITLE
docs: twoslashのtitleをコードの関数名に合わせるように修正

### DIFF
--- a/docs/reference/functions/arrow-functions.md
+++ b/docs/reference/functions/arrow-functions.md
@@ -26,7 +26,7 @@ const 変数名 = (引数) => {
 
 たとえば、次の[関数式](./function-expression.md)をアロー関数に書き直すと
 
-```js twoslash title="関数式で定義したhello関数"
+```js twoslash title="関数式で定義したincrement関数"
 const increment = function (n) {
   return n + 1;
 };
@@ -34,7 +34,7 @@ const increment = function (n) {
 
 次のようになります。
 
-```js twoslash title="アロー関数で定義したhello関数"
+```js twoslash title="アロー関数で定義したincrement関数"
 const increment = (n) => {
   return n + 1;
 };


### PR DESCRIPTION
コードに合わせて「hello関数」→「increment関数」へ修正しました。