### PR TITLE
docs: デフォルト型引数を指定するコードを追加

### DIFF
--- a/docs/reference/generics/default-type-parameter.md
+++ b/docs/reference/generics/default-type-parameter.md
@@ -53,7 +53,16 @@ const errorEvent: MyErrorEvent = {
 };
 ```
 
-そこで、デフォルト型引数として`Error`を指定することでジェネリクスの型`T`は必要な時だけ指定して、何も指定してない場合は自動で`Error`とすることができます。
+そこで、`<T = Error>`とすることでデフォルト型引数として`Error`を指定します。
+
+```ts twoslash
+type MyErrorEvent<T = Error> = {
+  error: T;
+  type: string;
+};
+```
+
+デフォルト型引数として`Error`を指定することでジェネリクスの型`T`は必要な時だけ指定して、何も指定してない場合は自動で`Error`とすることができます。
 
 ```ts twoslash
 type MyErrorEvent<T = Error> = {


### PR DESCRIPTION
デフォルト型引数を指定する方法が示されていなかったので、コードで例示しました。
検討いただけると幸いです。

関連ページ: https://typescriptbook.jp/reference/generics/default-type-parameter