### PR TITLE
誤植「ブラ`ン`ケット」→「ブラケット」

### DIFF
--- a/docs/reference/type-reuse/indexed-access-types.md
+++ b/docs/reference/type-reuse/indexed-access-types.md
@@ -75,7 +75,7 @@ type State = typeof stateList[number];
 
 ## タプル型とインデックスアクセス型
 
-インデックスアクセス型は[タプル型](../values-types-variables/tuple.md)の要素の型を参照するのにも使えます。タプル型の要素の型を参照するには、ブランケット記法に[数値リテラル型](../values-types-variables/literal-types.md)を書きます。
+インデックスアクセス型は[タプル型](../values-types-variables/tuple.md)の要素の型を参照するのにも使えます。タプル型の要素の型を参照するには、ブラケット記法に[数値リテラル型](../values-types-variables/literal-types.md)を書きます。
 
 ```ts twoslash
 type Tuple = [string, number];

--- a/docs/reference/values-types-variables/type-assertion-as.md
+++ b/docs/reference/values-types-variables/type-assertion-as.md
@@ -17,14 +17,14 @@ const value: string | number = "this is a string";
 const strLength: number = (value as string).length;
 ```
 
-もう1つはアングルブランケット構文(angle-bracket syntax)です。
+もう1つはアングルブラケット構文(angle-bracket syntax)です。
 
 ```ts twoslash
 const value: string | number = "this is a string";
 const strLength: number = (<string>value).length;
 ```
 
-どちらを用いるかは好みですが、アングルブランケット構文はJSXと見分けがつかないことがあるため、as構文が用いられることのほうが多いです。
+どちらを用いるかは好みですが、アングルブラケット構文はJSXと見分けがつかないことがあるため、as構文が用いられることのほうが多いです。
 
 ## コンパイルエラーになる型アサーション
 


### PR DESCRIPTION
表記揺れがあったため、一般的な方に修正しました。
ブランケットだと毛布などを連想してしまう気がします。
