### PR TITLE
docs: "user-defined type guard"の英語表記を補足として追加

### DIFF
--- a/docs/reference/statements/control-flow-analysis-and-type-guard.md
+++ b/docs/reference/statements/control-flow-analysis-and-type-guard.md
@@ -156,7 +156,7 @@ function attack(player: Wizard | SwordMan) {
 }
 ```
 
-この名称は英語としても長いらしく、型ガード関数(type guarding function, guard's function)と呼ばれることもあります。
+この名称(user-defined type guard)は英語としても長いらしく、型ガード関数(type guarding function, guard's function)と呼ばれることもあります。
 
 [型ガード関数](../functions/type-guard-functions.md)
 


### PR DESCRIPTION
”この名称は英語としても長いらしく”と記述があるのに
肝心の英語の名称が表記されておらず気になってしまったため
”user-defined type guard”を補足として追記します

”user defined”か"user-defined"か迷いましたが以下を参照して後者を採用しました
https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates
> To define a user-defined type guard, we simply need to define a function whose return type is a type predicate: