### PR TITLE
docs: 日本語の意味合いの違い

### DIFF
--- a/docs/reference/type-reuse/utility-types/omit.md
+++ b/docs/reference/type-reuse/utility-types/omit.md
@@ -64,7 +64,7 @@ type Person = Omit<User, Optional>;
 // このPersonは下の型になる
 ```
 
-`User`の`createdAt`,、`updatedAt`の`At`は大文字から始まりますが、これに気づかずに小文字で書いてしまっても、`Omit`の結果は`createdAt`と`updatedAt`を含んでしまいます。
+`User`の`createdAt`,、`updatedAt`の`At`は大文字から始まりますが、これに気づかずに小文字で書いてしまったため、`Omit`の結果は`createdAt`と`updatedAt`を含んでしまいます。
 
 ## 関連情報
 


### PR DESCRIPTION
「これに気づかずに小文字で書いてしまった」の「`Omit`の結果は`createdAt`と`updatedAt`を含んでしまいます」に対する関係は逆接ではなく原因となるため、「しまっても」から「しまったため」に修正しました。