### PR TITLE
JSXのセルフクロージング要素について記述を追加 

### DIFF
--- a/docs/tutorials/react-like-button-tutorial.md
+++ b/docs/tutorials/react-like-button-tutorial.md
@@ -234,7 +234,7 @@ JSXを戻り値にする関数をReact用語で「関数コンポーネント」
 
 先ほども書いたように、JSXはJavaScriptの拡張構文であり、厳密にはHTMLと異なるものです。そのため、JSXにはHTMLとは異なる書き方や制約があります。
 
-`<LikeButton />`のようにスラッシュをタグに含める書き方も、JSXならではの書き方です。これはセルフクロージング要素([JSXの仕様](https://facebook.github.io/jsx/#sec-jsx-elements)における名称は"JSXSelfClosingElement")と呼ばれます。`<LikeButton></LikeButton>`のように子要素などを持たない場合に、`<LikeButton />`のように末尾に`/`をつけることで、短く表現できる書き方です。
+`<LikeButton />`のようにスラッシュをタグに含める書き方も、JSXならではの書き方です。これはセルフクロージング要素(self-closing element)と呼ばれます。`<LikeButton></LikeButton>`のように子要素などを持たない場合に、`<LikeButton />`のように末尾に`/`をつけることで、短く表現できる書き方です。
 
 JSXとHTMLのその他の違いについては、[Reactの公式ドキュメント](https://beta.reactjs.org/learn/writing-markup-with-jsx)を参照してください。
 

--- a/docs/tutorials/react-like-button-tutorial.md
+++ b/docs/tutorials/react-like-button-tutorial.md
@@ -230,6 +230,16 @@ JSXを戻り値にする関数をReact用語で「関数コンポーネント」
 
 :::
 
+:::tip ワンポイント解説: JSXのセルフクロージング要素
+
+先ほども書いたように、JSXはJavaScriptの拡張構文であり、厳密にはHTMLと異なるものです。そのため、JSXにはHTMLとは異なる書き方や制約があります。
+
+上の例における`App`関数の返り値のJSXにおける`<LikeButton />`という書き方も、HTMLではできないもののJSXではできる書き方の1つです。これは「セルフクロージング要素(タグ)」([JSXの仕様](https://facebook.github.io/jsx/#sec-jsx-elements)における名称は"JSXSelfClosingElement")と呼ばれ、`<LikeButton></ LikeButton>`というように子要素やテキストを持たない要素については、`<LikeButton />`というように末尾に`/`を付けた単体のタグで表現するというものです。
+
+JSXとHTMLのその他の違いについては、たとえば[Reactの公式ドキュメント](https://beta.reactjs.org/learn/writing-markup-with-jsx)を参照してください。
+
+:::
+
 ## ボタンのビジュアルを作り込む
 
 いいねボタンの実装場所が確保できたので、ここではボタンのタグを変更したり、CSSを書いたりして、ボタンの見た目を作っていきます。今回作るボタンは次の図のようなシンプルなものです。

--- a/docs/tutorials/react-like-button-tutorial.md
+++ b/docs/tutorials/react-like-button-tutorial.md
@@ -234,9 +234,9 @@ JSXを戻り値にする関数をReact用語で「関数コンポーネント」
 
 先ほども書いたように、JSXはJavaScriptの拡張構文であり、厳密にはHTMLと異なるものです。そのため、JSXにはHTMLとは異なる書き方や制約があります。
 
-上の例における`App`関数の返り値のJSXにおける`<LikeButton />`という書き方も、JSXならではの書き方です。これは「セルフクロージング要素(タグ)」([JSXの仕様](https://facebook.github.io/jsx/#sec-jsx-elements)における名称は"JSXSelfClosingElement")と呼ばれ、`<LikeButton></ LikeButton>`というように子要素やテキストを持たない要素については、`<LikeButton />`というように末尾に`/`を付けた単体のタグで表現するというものです。
+`<LikeButton />`のようにスラッシュをタグに含める書き方も、JSXならではの書き方です。これはセルフクロージング要素([JSXの仕様](https://facebook.github.io/jsx/#sec-jsx-elements)における名称は"JSXSelfClosingElement")と呼ばれます。`<LikeButton></LikeButton>`のように子要素などを持たない場合に、`<LikeButton />`のように末尾に`/`をつけることで、短く表現できる書き方です。
 
-JSXとHTMLのその他の違いについては、たとえば[Reactの公式ドキュメント](https://beta.reactjs.org/learn/writing-markup-with-jsx)を参照してください。
+JSXとHTMLのその他の違いについては、[Reactの公式ドキュメント](https://beta.reactjs.org/learn/writing-markup-with-jsx)を参照してください。
 
 :::
 

--- a/docs/tutorials/react-like-button-tutorial.md
+++ b/docs/tutorials/react-like-button-tutorial.md
@@ -234,7 +234,7 @@ JSXを戻り値にする関数をReact用語で「関数コンポーネント」
 
 先ほども書いたように、JSXはJavaScriptの拡張構文であり、厳密にはHTMLと異なるものです。そのため、JSXにはHTMLとは異なる書き方や制約があります。
 
-上の例における`App`関数の返り値のJSXにおける`<LikeButton />`という書き方も、HTMLではできないもののJSXではできる書き方の1つです。これは「セルフクロージング要素(タグ)」([JSXの仕様](https://facebook.github.io/jsx/#sec-jsx-elements)における名称は"JSXSelfClosingElement")と呼ばれ、`<LikeButton></ LikeButton>`というように子要素やテキストを持たない要素については、`<LikeButton />`というように末尾に`/`を付けた単体のタグで表現するというものです。
+上の例における`App`関数の返り値のJSXにおける`<LikeButton />`という書き方も、JSXならではの書き方です。これは「セルフクロージング要素(タグ)」([JSXの仕様](https://facebook.github.io/jsx/#sec-jsx-elements)における名称は"JSXSelfClosingElement")と呼ばれ、`<LikeButton></ LikeButton>`というように子要素やテキストを持たない要素については、`<LikeButton />`というように末尾に`/`を付けた単体のタグで表現するというものです。
 
 JSXとHTMLのその他の違いについては、たとえば[Reactの公式ドキュメント](https://beta.reactjs.org/learn/writing-markup-with-jsx)を参照してください。
 

--- a/docs/tutorials/react-like-button-tutorial.md
+++ b/docs/tutorials/react-like-button-tutorial.md
@@ -234,7 +234,7 @@ JSXを戻り値にする関数をReact用語で「関数コンポーネント」
 
 先ほども書いたように、JSXはJavaScriptの拡張構文であり、厳密にはHTMLと異なるものです。そのため、JSXにはHTMLとは異なる書き方や制約があります。
 
-`<LikeButton />`のようにスラッシュをタグに含める書き方も、JSXならではの書き方です。これはセルフクロージング要素(self-closing element)と呼ばれます。`<LikeButton></LikeButton>`のように子要素などを持たない場合に、`<LikeButton />`のように末尾に`/`をつけることで、短く表現できる書き方です。
+`<LikeButton />`のようにスラッシュをタグに含める書き方も、JSXならではの書き方です。これはセルフクロージング要素(self-closing element)と呼ばれます。自己閉じ要素、自己完結型要素と呼ばれることもあります。`<LikeButton></LikeButton>`のように子要素などを持たない場合に、`<LikeButton />`のように末尾に`/`をつけることで、短く表現できる書き方です。
 
 JSXとHTMLのその他の違いについては、[Reactの公式ドキュメント](https://beta.reactjs.org/learn/writing-markup-with-jsx)を参照してください。
 


### PR DESCRIPTION
- JSXのセルフクロージング要素について記述を追加
- docs: 📚 self-closingが「HTMLにはできない」を削除しました。
- feat: 🎸 文の濃度を上げました。
- feat: 🎸 JSXのシンタクス仕様書へのリンクを除きました。
- feat: 🎸 「自己閉じ要素」「自己完結型要素」と呼ばれることもある旨を追記しました。

close #363 #557
