### PR TITLE
EditorConfigの説明の追加

### DIFF
--- a/docs/tutorials/prettier.md
+++ b/docs/tutorials/prettier.md
@@ -251,6 +251,43 @@ singleQuote = true
 | yaml         | `.prettierrc`, `.prettierrc.yml`, `.prettierrc.yaml`                                    |
 | toml         | `.prettierrc.toml`                                                                      |
 
+### EditorConfigを利用する
+
+Prettierは、[EditorConfig](https://editorconfig.org/)という、全開発参加者の間でインデントのスタイルや改行文字の種類などを統一させる仕組みに対応しています。プロジェクトルートに`.editorconfig`というファイルを置くと、対応しているテキストエディターやIDE、Prettier等がそれを読み込んで、インデントスタイル等を書かれた内容に合わせます。  
+`.editorconfig`ファイルの例を次のとおり示します。
+
+```ini title=".editorconfig"
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.{py,rs,php,go,kt,swift,java,zig,cs,vb}]
+indent_size = 4
+
+[*.{go,mk},Makefile]
+indent_style = tab
+
+[*.mk,Makefile]
+indent_size = 8
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{cs,vb}]
+charset = utf-8-bom
+end_of_file = crlf
+```
+
+このファイルがプロジェクトルートにあると、Prettierはそれを検知し、`.prettierrc`がなくてもスペース2つでフォーマットします。シングルクォートを使うか・セミコロンを挿入するか等の設定などをしたい場合は、`.prettierrc`を別途作成する必要がありますが、`tabWidth`・`useTabs`・`endOfLine`の項目は指定しなくてよくなります。
+
+Prettierの他にも、VSCodeも[プラグイン](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig)経由で対応している他、IntelliJ IDEAやVisual Studioも対応しています。それらでのエディターでファイルの新規作成を行うと、`.editorconfig`に書かれたルールに沿うようにエディターの設定が一時的に変更されます。
+
 ### 他の整形ルールを確認する
 
 ここで紹介した以外にもいくつかの整形ルールが存在します。


### PR DESCRIPTION
Prettierは[EditorConfig](https://editorconfig.org/)を参照してインデント設定を決めることができるので、それの説明を追加しました。
VSCode等主要なエディタやIDEも対応しています。