### PR TITLE
各種設定の改良

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.{py,rs,php,go,kt,swift,java,zig}]
+indent_size = 4
+
+[*.{go,mk},Makefile]
+indent_style = tab
+
+[*.mk,Makefile]
+indent_size = 8
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
+* text=auto eol=lf 
 *.ai -diff

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,3 +10,5 @@
 /build
 pnpm-lock.yaml
 /.cache
+
+/.yarn

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "開発サーバーの起動",
+      "skipFiles": ["<node_internals>/**"],
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": ["start"]
+    }
+  ]
+}


### PR DESCRIPTION
- `.editorconfig`の追加
  - Windowsでも、新規作成時にスペース2・改行LFを強制できます
- `.gitattributes`にて、改行LFでコミット・チェックアウトするように
  - 同じくWindowsで、チェックアウト時に勝手に改行をCRLFに変えないように
    参考：https://qiita.com/Yossy_Hal/items/6fe2d14cddd6e16796d7
- VSCodeで、F5を押せば`yarn start`を実行できるように
- `.yarn`ディレクトリをPrettierのフォーマット対象から外す（`prettier -w .`・`prettier -c .`もOKになるように）