### PR TITLE
docs: 📚配列 => タプル型

### DIFF
--- a/docs/reference/type-reuse/indexed-access-types.md
+++ b/docs/reference/type-reuse/indexed-access-types.md
@@ -65,7 +65,7 @@ type T = MixedArray[number];
 //   ^?
 ```
 
-[`typeof`型演算子](typeof-type-operator.md)と組み合わせると、配列の値から要素の型を導くこともできます。
+[`typeof`型演算子](typeof-type-operator.md)と組み合わせると、[タプル型](../values-types-variables/tuple.md)の値から各要素の型を導くこともできます。
 
 ```ts twoslash
 const stateList = ["open", "closed"] as const;


### PR DESCRIPTION
釈迦に説法ですが
```typescript
const stateList = ["open", "closed"] as const;
```
はタプルなので、誤解を与えぬよう修正しましたm(__)m