### PR TITLE
docs: サンプルコードの並び順を文章構成に合わせる

### DIFF
--- a/docs/reference/object-oriented/interface/interface-vs-type-alias.md
+++ b/docs/reference/object-oriented/interface/interface-vs-type-alias.md
@@ -8,14 +8,14 @@ description: interfaceでの宣言とtype aliasによる宣言の違い
 
 ```ts twoslash
 // @noErrors
-type Animal = {
-  name: string;
-  bark(): string;
-};
 interface Animal {
   name: string;
   bark(): string;
 }
+type Animal = {
+  name: string;
+  bark(): string;
+};
 ```
 
 この章では、インターフェースと型エイリアスの違いについて詳しく説明していきます。


### PR DESCRIPTION
細かい点で恐縮ですが、

「interfaceとtypeの違い」ページの最初のサンプルコードにおいて、ページのタイトルや文章構成及び後続の例に合わせて、上からinterface→typeと並ぶように修正しました
