### PR TITLE
「日英対訳表」に対訳を追加

### DIFF
--- a/docs/writing/japanese-english-table.md
+++ b/docs/writing/japanese-english-table.md
@@ -41,10 +41,11 @@
   - 明確な割り当てアサーション
 - Declaration merging
   - 宣言マージ
+- Assertion functions
+  - アーサーション関数
 
 <!--textlint-enable prh-->
 
 ## 日本語が不明
 
-- Assertion functions
 - Type predicate

--- a/docs/writing/japanese-english-table.md
+++ b/docs/writing/japanese-english-table.md
@@ -39,6 +39,8 @@
   - Deep Diveでは「マップ型」と訳している箇所もあるが、`Map<T, U>`との曖昧さが出てしまう恐れがあるので和訳はしない。
 - Definite assignment assertion
   - 明確な割り当てアサーション
+- Declaration merging
+  - 宣言マージ
 
 <!--textlint-enable prh-->
 
@@ -46,4 +48,3 @@
 
 - Assertion functions
 - Type predicate
-- Declaration merging


### PR DESCRIPTION
<!--
本プロジェクトではチケット駆動を原則としています。GitHubのキーワードを用いたissueの関連付け機能を用いて、対応したissueをプルリクエストに関連付けてください。

・チケット駆動: https://typescriptbook.jp/writing/ticket-driven
・issue関連付け機能: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #664
Fixes #618 


確認用URL: https://book-git-fork-hayashi-ay-fix-664-yytypescript.vercel.app/writing/japanese-english-table