### PR TITLE
fix: "Student型かを判定する型ガード関数"が正しく判定されるように修正

### DIFF
--- a/docs/reference/object-oriented/interface/instanceof-and-interfaces.md
+++ b/docs/reference/object-oriented/interface/instanceof-and-interfaces.md
@@ -56,11 +56,11 @@ function isStudent(value: unknown): value is Student {
   }
   const { name, grade } = value as Record<keyof Student, unknown>;
   // nameプロパティーが文字列型かを判定
-  if (typeof name === "string") {
+  if (typeof name !== "string") {
     return false;
   }
   // gradeプロパティーが数値型かを判定
-  if (typeof grade === "number") {
+  if (typeof grade !== "number") {
     return false;
   }
   return true;
@@ -83,11 +83,11 @@ function isStudent(value: unknown): value is Student {
   }
   const { name, grade } = value as Record<keyof Student, unknown>;
   // nameプロパティが文字列型かを判定
-  if (typeof name === "string") {
+  if (typeof name !== "string") {
     return false;
   }
   // gradeプロパティが数値型かを判定
-  if (grade === "number") {
+  if (grade !== "number") {
     return false;
   }
   return true;

--- a/docs/reference/object-oriented/interface/instanceof-and-interfaces.md
+++ b/docs/reference/object-oriented/interface/instanceof-and-interfaces.md
@@ -87,7 +87,7 @@ function isStudent(value: unknown): value is Student {
     return false;
   }
   // gradeプロパティが数値型かを判定
-  if (grade !== "number") {
+  if (typeof grade !== "number") {
     return false;
   }
   return true;


### PR DESCRIPTION
現在の例だとプロパティの型が正しく判定されないので修正しました。

```ts
interface Student {
  name: string;
  grade: number;
}
 
// Student型かを判定する型ガード関数
function isStudent(value: unknown): value is Student {
  // 値がオブジェクトであるかの判定
  if (typeof value !== "object" || value === null) {
    return false;
  }
  const { name, grade } = value as Record<keyof Student, unknown>;
  // nameプロパティーが文字列型かを判定
  if (typeof name === "string") {
    return false;
  }
  // gradeプロパティーが数値型かを判定
  if (typeof grade === "number") {
    return false;
  }
  return true;
}

console.log(isStudent({ name: [], grade: [] })); // true 👎
console.log(isStudent({ name: 'hoge', grade: 1 })); // false 👎
```

Fix #680