### PR TITLE
PRのテンプレートにチケットのクローズを追加

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,3 +4,5 @@
 ・チケット駆動: https://typescriptbook.jp/writing/ticket-driven
 ・issue関連付け機能: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
 -->
+
+close #<ISSUE番号>

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,3 +1,5 @@
+.github/PULL_REQUEST_TEMPLATE.md
+
 node_modules
 
 #


### PR DESCRIPTION
<!--
本プロジェクトではチケット駆動を原則としています。GitHubのキーワードを用いたissueの関連付け機能を用いて、対応したissueをプルリクエストに関連付けてください。

・チケット駆動: https://typescriptbook.jp/writing/ticket-driven
・issue関連付け機能: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## やったこと
チケット駆動で関連するISSUEの関連付けやり忘れる事を防止する目的で、PRテンプレートに `close #<ISSUE番号>` を追加

close #626 