### PR TITLE
誤植訂正 swicth → switch

### DIFF
--- a/docs/reference/values-types-variables/typeof-operator.md
+++ b/docs/reference/values-types-variables/typeof-operator.md
@@ -19,7 +19,7 @@ typeof { a: 1, b: 2 }; //=> "object"
 typeof (() => {}); //=> "function"
 ```
 
-## TypeScriptで`typeof`を使うとifやswicthでその型として使うことができる
+## TypeScriptで`typeof`を使うとifやswitchでその型として使うことができる
 
 TypeScriptでは`typeof`演算子をifやswitchと併せてつかうと、条件と合致したときにその変数をその型として扱えるようになります。次の例は`unknown`型とされた変数`n`が`typeof`演算子によって`string`型であると判別された例です。
 


### PR DESCRIPTION
<!--
本プロジェクトではチケット駆動を原則としています。GitHubのキーワードを用いたissueの関連付け機能を用いて、対応したissueをプルリクエストに関連付けてください。

・チケット駆動: https://typescriptbook.jp/writing/ticket-driven
・issue関連付け機能: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

https://github.com/yytypescript/book/blob/bc6273bfe3dd48e59fb4bff25261fbb6d34b53d7/docs/reference/values-types-variables/typeof-operator.md?plain=1#L22

表題の通りですが、swi`ct`h → swi`tc`h へ修正しました。

close #692
