### PR TITLE
「コンポーネントテストの「ボタンをクリックするとON/OFFの表示が切り替わる」がtesting-library/user-event@14でFAILになる問題を解決しました。

### DIFF
--- a/docs/tutorials/component-test.md
+++ b/docs/tutorials/component-test.md
@@ -9,31 +9,39 @@
 - UIテストのためのライブラリ群`testing-library`を使ったテストの作成
 - `Jest`を使ったスナップショットテストの作成
 
-本章の目的はコンポーネントのテストを完全に理解することではありません。むしろ、それがどういったものなのか、その雰囲気を実際に体験することに主眼を置いています。
-そのため、内容はかなり最低限のものとなりますが、逆に言えば少しの時間でコンポーネントテストを試してみれるシンプルな内容にまとまってますから、ぜひ手を動かしてみてください。
+本章の目的はコンポーネントのテストを完全に理解することではありません。むしろ、それがどういったものなのか、その雰囲気を実際に体験することに主眼を置いています。そのため、内容はかなり最低限のものとなりますが、逆に言えば少しの時間でコンポーネントテストを試してみれるシンプルな内容にまとまってますから、ぜひ手を動かしてみてください。
 
 :::info
 Reactでコンポーネントが作れることを前提にしますので、Reactの基本的な使い方を知りたいという方は[Reactでいいねボタンを作ろう](./react-like-button-tutorial.md)をご参照ください。
 :::
+
+このチュートリアルで作成するテストコードの完成形は[GitHub](https://github.com/yytypescript/component-test-tutorial/blob/main/src/SimpleButton.test.tsx)で確認することができます。
+
+## このチュートリアルに必要なもの
+
+このチュートリアルをやるに当たって、必要なツールがあります。それらはここにリストアップしておくのであらかじめ用意しておいてください。
+
+- Node.js (このチュートリアルではv18.15.0で動作確認しています)
+- NPM
+- Yarn v1系 (このチュートリアルはv1.22.19で動作確認しています)
+
+Node.jsの導入については、[開発環境の準備](./setup.md)をご覧ください。
+
+パッケージ管理ツールとしてYarnを利用します。最初にインストールをしておきましょう。すでにインストール済みの方はここのステップはスキップして大丈夫です。
+
+```shell
+npm install -g yarn
+```
 
 ## Reactプロジェクトの作成
 
 テストに使用するためのReactプロジェクトを作成します。下記コマンドを実行してください。
 
 ```shell
-npx create-react-app component-test-tutorial --template typescript
+yarn create react-app component-test-tutorial --template typescript
 ```
 
-上記を実行すると次のように聞かれることがありますが、`y`を押して`create-react-app`をインストールしてください。時間がかかることもあるので、のんびり待ちましょう。
-
-```shell
-Need to install the following packages:
-  create-react-app
-Ok to proceed? (y)
-```
-
-成功すると今いるディレクトリ配下に`component-test-tutorial`というディレクトリが作られます。
-そのまま下記コマンドを実行して`component-test-tutorial`に移動しましょう。
+成功すると今いるディレクトリ配下に`component-test-tutorial`というディレクトリが作られます。そのまま下記コマンドを実行して`component-test-tutorial`に移動しましょう。
 
 ```shell
 cd component-test-tutorial
@@ -42,13 +50,29 @@ cd component-test-tutorial
 `component-test-tutorial`配下のファイル構成は次のようになっているはずです。
 
 ```text
-├── README.md
+├── .gitignore
 ├── node_modules
-├── package-lock.json
+├── README.md
 ├── package.json
 ├── public
+│   ├── favicon.ico
+│   ├── index.html
+│   ├── logo192.png
+│   ├── logo512.png
+│   ├── manifest.json
+│   └── robots.txt
 ├── src
-└── tsconfig.json
+│   ├── App.css
+│   ├── App.test.tsx
+│   ├── App.tsx
+│   ├── index.css
+│   ├── index.tsx
+│   ├── logo.svg
+│   ├── react-app-env.d.ts
+│   ├── reportWebVitals.ts
+│   └── setupTests.ts
+├── tsconfig.json
+└── yarn.lock
 ```
 
 ここで次のコマンドを実行してください。
@@ -63,8 +87,7 @@ yarn start
 
 ## テストするコンポーネント
 
-ここでは、簡単なボタンコンポーネントのテストを書くことを例に進めていきます。
-具体的には、はじめは`OFF`となっているボタン上の文字が、ボタンをクリックするたびに`ON`/`OFF`と切り替わるようなボタンを題材にします。
+ここでは、簡単なボタンコンポーネントのテストを書くことを例に進めていきます。具体的には、はじめは`OFF`となっているボタン上の文字が、ボタンをクリックするたびに`ON`/`OFF`と切り替わるようなボタンを題材にします。
 
 ![ボタン上の文字がクリックによってON,OFFと切り替わる様子](component-test/simpleButton.gif)
 
@@ -72,8 +95,7 @@ yarn start
 
 ## テスト対象のコンポーネントを作る
 
-テストを作成するために、まずはテスト対象となるコンポーネントを実装していきます。
-`src`ディレクトリ配下に、`SimpleButton.tsx`という名前でファイルを作成してください。
+テストを作成するために、まずはテスト対象となるコンポーネントを実装していきます。`src`ディレクトリ配下に、`SimpleButton.tsx`という名前でファイルを作成してください。
 
 ```shell
 cd src
@@ -86,13 +108,13 @@ touch SimpleButton.tsx
 ├── App.css
 ├── App.test.tsx
 ├── App.tsx
+├── SimpleButton.tsx
 ├── index.css
 ├── index.tsx
 ├── logo.svg
 ├── react-app-env.d.ts
 ├── reportWebVitals.ts
-├── setupTests.ts
-└── SimpleButton.tsx
+└── setupTests.ts
 ```
 
 `SimpleButton.tsx`の内容は次のようにします。
@@ -110,8 +132,7 @@ export const SimpleButton: () => JSX.Element = () => {
 };
 ```
 
-ここで、この`SimpleButton`コンポーネントの挙動を確認してみましょう。
-`index.tsx`ファイルを次のようにして保存してください。
+ここで、この`SimpleButton`コンポーネントの挙動を確認してみましょう。`index.tsx`ファイルを次のようにして保存してください。
 
 ```tsx twoslash title="index.tsx"
 // @noErrors
@@ -135,8 +156,7 @@ root.render(
 yarn start
 ```
 
-すると、ブラウザが自動で立ち上がり、次のようなボタンが表示されます。
-初めは`OFF`と表示され、クリックにより`ON`と`OFF`が交互に切り替わることを確認してください。
+すると、ブラウザが自動で立ち上がり、次のようなボタンが表示されます。初めは`OFF`と表示され、クリックにより`ON`と`OFF`が交互に切り替わることを確認してください。
 
 ![ボタン上の文字がクリックによってON,OFFと切り替わる様子](component-test/simpleButton.gif)
 
@@ -148,14 +168,24 @@ yarn start
 
 ## `testing-library`を使ったテストの作り方とやり方
 
-ここからはテストの作り方とやり方に入ります。
-今回は、ボタンをクリックすると`ON`/`OFF`の表示が切り替わることをテストしていきます。
+ここからはテストの作り方とやり方に入ります。今回は、ボタンをクリックすると`ON`/`OFF`の表示が切り替わることをテストしていきます。
 
-Reactコンポーネントをテストする方法は複数ありますが、ここでは利用者が比較的多い`testing-library`というライブラリ群を用いる方法を紹介します。
-`testing-library`はUIコンポーネントのテストをするためのライブラリ群であり、コンポーネントの描画やコンポーネントに対する操作などが実現できます。`testing-library`があれば、コンポーネントのテストはひととおりできると考えてよいでしょう。
+Reactコンポーネントをテストする方法は複数ありますが、ここでは利用者が比較的多い`testing-library`というライブラリ群を用いる方法を紹介します。`testing-library`はUIコンポーネントのテストをするためのライブラリ群であり、コンポーネントの描画やコンポーネントに対する操作などが実現できます。`testing-library`があれば、コンポーネントのテストはひととおりできると考えてよいでしょう。
 
-それでは、実際に`testing-library`を使ってテストを作っていきましょう。
-まずは先ほどと同じ`src`ディレクトリ配下で`SimpleButton.test.tsx`というファイルを作成します。
+### testing-libraryをインストールする
+
+次のコマンドを実行してtesting-libraryをインストールしてください。
+
+```shell
+yarn add \
+  @testing-library/react@14 \
+  @testing-library/jest-dom@5 \
+  @testing-library/user-event@14
+```
+
+### テストを作る
+
+それでは、実際に`testing-library`を使ってテストを作っていきましょう。まずは先ほどと同じ`src`ディレクトリ配下で`SimpleButton.test.tsx`というファイルを作成します。
 
 ```shell
 touch SimpleButton.test.tsx
@@ -165,7 +195,7 @@ touch SimpleButton.test.tsx
 
 ```tsx twoslash title="SimpleButton.test.tsx"
 // @noErrors
-test("ボタンをクリックするとON/OFFの表示が切り替わる", () => {
+test("ボタンをクリックするとON/OFFの表示が切り替わる", async () => {
   // ここにテストの中身を書いていきます
 });
 ```
@@ -183,91 +213,90 @@ test("ボタンをクリックするとON/OFFの表示が切り替わる", () =>
 1. コンポーネントに操作を施す
 2. コンポーネントの状態を確かめる
 
-今回の例もボタンを描画した後、「`OFF`と表示されている」という状態確認から始まり、「クリック」という操作を施した後、再び「`ON`と表示されている」という状態確認をします。
-みなさんが自分でコンポーネントのテストを書く際も、どのような操作と状態確認を行えばよいかを意識することでテスト作成がスムーズにできるはずです。
+今回の例もボタンを描画した後、「`OFF`と表示されている」という状態確認から始まり、「クリック」という操作を施した後、再び「`ON`と表示されている」という状態確認をします。みなさんが自分でコンポーネントのテストを書く際も、どのような操作と状態確認を行えばよいかを意識することでテスト作成がスムーズにできるはずです。
 :::
 
-まずはボタンを描画してみましょう。
-コンポーネントの描画は`@testing-library/react`の`render()`を使って、次のようにするだけです。なお、この`@testing-library/react`というライブラリは、今回`create-react-app`でReactアプリケーションを作成したためすでにプロジェクトにインストールされています。
+まずはボタンを描画してみましょう。コンポーネントの描画は`@testing-library/react`の`render()`を使って、次のようにするだけです。なお、この`@testing-library/react`というライブラリは、今回`create-react-app`でReactアプリケーションを作成したためすでにプロジェクトにインストールされています。
 
-```tsx twoslash title="SimpleButton.test.tsx"
+```tsx twoslash {1,2,5} title="SimpleButton.test.tsx"
 // @noErrors
 import { render } from "@testing-library/react";
 import { SimpleButton } from "./SimpleButton";
 
-test("ボタンをクリックするとON/OFFの表示が切り替わる", () => {
+test("ボタンをクリックするとON/OFFの表示が切り替わる", async () => {
   render(<SimpleButton />);
 });
 ```
 
-ボタンが描画されたので、次は`OFF`と表示されていることを確かめます。具体的には、ボタンのDOM(DOMとは、ここではボタンを表すオブジェクトくらいに捉えていただければ大丈夫です)を取得し、そのテキストが`OFF`という文字列に等しいかのアサーションを実施します。
-今回、ボタンのDOMの取得には`@testing-library/react`が提供するクエリのひとつである`getByRole()`を使います。これは[WAI-ARIA](https://developer.mozilla.org/ja/docs/Learn/Accessibility/WAI-ARIA_basics)(アクセシビリティ向上を主目的として定められたwebの仕様)で定められたRoleを引数に指定すると、そのRoleを持つコンポーネントを取得するクエリです。詳細は[公式ドキュメント](https://testing-library.com/docs/queries/byrole)をご参照ください。
+ボタンが描画されたので、次は`OFF`と表示されていることを確かめます。具体的には、ボタンのDOM(DOMとは、ここではボタンを表すオブジェクトくらいに捉えていただければ大丈夫です)を取得し、そのテキストが`OFF`という文字列に等しいかのアサーションを実施します。今回、ボタンのDOMの取得には`@testing-library/react`が提供するクエリのひとつである`getByRole()`を使います。これは[WAI-ARIA](https://developer.mozilla.org/ja/docs/Learn/Accessibility/WAI-ARIA_basics)(アクセシビリティ向上を主目的として定められたwebの仕様)で定められたRoleを引数に指定すると、そのRoleを持つコンポーネントを取得するクエリです。詳細は[公式ドキュメント](https://testing-library.com/docs/queries/byrole)をご参照ください。具体的には、このように書けます。
 
-具体的には、このように書けます。
-
-```tsx twoslash title="SimpleButton.test.tsx"
+```tsx twoslash {1-2,7} title="SimpleButton.test.tsx"
 // @noErrors
 import { render, screen } from "@testing-library/react";
+//               ^^^^^^追加
 import { SimpleButton } from "./SimpleButton";
 
-test("ボタンをクリックするとON/OFFの表示が切り替わる", () => {
+test("ボタンをクリックするとON/OFFの表示が切り替わる", async () => {
   render(<SimpleButton />);
   const simpleButton = screen.getByRole("button");
 });
 ```
 
-そして、ボタンのテキストのアサーションは`@testing-library/jest-dom`が提供する`toHaveTextContent()`を使います。
-`expect()`にコンポーネントを渡し、そのまま`toHaveTextContent()`を呼び出すと、そのコンポーネントがどのようなテキストを持っているかのアサーションが行なえます。
-具体的には次のようになります。
+そして、ボタンのテキストのアサーションは`@testing-library/jest-dom`が提供する`toHaveTextContent()`を使います。`expect()`にコンポーネントを渡し、そのまま`toHaveTextContent()`を呼び出すと、そのコンポーネントがどのようなテキストを持っているかのアサーションが行なえます。具体的には次のようになります。
 
-```tsx twoslash title="SimpleButton.test.tsx"
+```tsx twoslash {7} title="SimpleButton.test.tsx"
 // @noErrors
 import { render, screen } from "@testing-library/react";
 import { SimpleButton } from "./SimpleButton";
 
-test("ボタンをクリックするとON/OFFの表示が切り替わる", () => {
+test("ボタンをクリックするとON/OFFの表示が切り替わる", async () => {
   render(<SimpleButton />);
   const simpleButton = screen.getByRole("button");
   expect(simpleButton).toHaveTextContent("OFF");
 });
 ```
 
-ここで一旦`yarn test`コマンドでテストを実行し、テストが通ることを確認しましょう。次のような結果になるはずです。
+ここで一旦`yarn test`コマンドでテストを実行し、テストが通ることを確認しましょう。
+
+```shell
+yarn test
+```
+
+次のような結果になるはずです。
 
 ![テストがPASSしているコンソールの画面](component-test/result_pass2.png)
 
-さて、次にボタンをクリックします。
-コンポーネントの操作は`testing-library`に収録されている`@testing-library/user-event`を使って実現できます。`@testing-library/user-event`はコンポーネントの操作を含む、色々なユーザーイベントをテストで実行するライブラリです。
-具体的には`click()`にクエリでみつけた`simpleButton`を引数として渡すことで、ボタンのクリックを実現できます。
+さて、次にボタンをクリックします。コンポーネントの操作は`testing-library`に収録されている`@testing-library/user-event`を使って実現できます。`@testing-library/user-event`はコンポーネントの操作を含む、色々なユーザーイベントをテストで実行するライブラリです。具体的には`click()`にクエリでみつけた`simpleButton`を引数として渡すことで、ボタンのクリックを実現できます。
 
-```tsx twoslash title="SimpleButton.test.tsx"
+```tsx twoslash {2,6,10} title="SimpleButton.test.tsx"
 // @noErrors
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { SimpleButton } from "./SimpleButton";
 
-test("ボタンをクリックするとON/OFFの表示が切り替わる", () => {
+test("ボタンをクリックするとON/OFFの表示が切り替わる", async () => {
+  const user = userEvent.setup();
   render(<SimpleButton />);
   const simpleButton = screen.getByRole("button");
   expect(simpleButton).toHaveTextContent("OFF");
-  userEvent.click(simpleButton);
+  await user.click(simpleButton);
 });
 ```
 
-続けて、ボタンがクリックされた後のアサーションを実施します。
-先ほどと同様に`toHaveTextContent()`を用いますが、今度はボタンのテキストが`ON`になっていることを確認しましょう。
+続けて、ボタンがクリックされた後のアサーションを実施します。先ほどと同様に`toHaveTextContent()`を用いますが、今度はボタンのテキストが`ON`になっていることを確認しましょう。
 
-```tsx twoslash title="SimpleButton.test.tsx"
+```tsx twoslash {11} title="SimpleButton.test.tsx"
 // @noErrors
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { SimpleButton } from "./SimpleButton";
 
-test("ボタンをクリックするとON/OFFの表示が切り替わる", () => {
+test("ボタンをクリックするとON/OFFの表示が切り替わる", async () => {
+  const user = userEvent.setup();
   render(<SimpleButton />);
   const simpleButton = screen.getByRole("button");
   expect(simpleButton).toHaveTextContent("OFF");
-  userEvent.click(simpleButton);
+  await user.click(simpleButton);
   expect(simpleButton).toHaveTextContent("ON");
 });
 ```
@@ -276,16 +305,13 @@ test("ボタンをクリックするとON/OFFの表示が切り替わる", () =>
 
 ![テストがPASSしているコンソールの画面](component-test/result_pass2.png)
 
-以上が、`testing-library`を用いてコンポーネントのテストを作成する流れです。
-`testing-library`からは、ここで紹介したもの以外にも多くのクエリやアサーション、ユーザーイベントの機能が提供されています。
-英語にはなってしまいますが、クエリは[こちら](https://testing-library.com/docs/queries/about)、アサーションは[こちら](https://github.com/testing-library/jest-dom#custom-matchers)、ユーザーイベントは[こちら](https://testing-library.com/docs/user-event/intro)に公式ドキュメントによる詳細な説明があります。実際に自分でテストを作る際には、ぜひそれらも確認してみてください。
+以上が、`testing-library`を用いてコンポーネントのテストを作成する流れです。`testing-library`からは、ここで紹介したもの以外にも多くのクエリやアサーション、ユーザーイベントの機能が提供されています。英語にはなってしまいますが、クエリは[こちら](https://testing-library.com/docs/queries/about)、アサーションは[こちら](https://github.com/testing-library/jest-dom#custom-matchers)、ユーザーイベントは[こちら](https://testing-library.com/docs/user-event/intro)に公式ドキュメントによる詳細な説明があります。実際に自分でテストを作る際には、ぜひそれらも確認してみてください。
 
 ## `Jest`を使ったスナップショットテストの作り方とやり方
 
 ここからは「スナップショットテスト」と呼ばれるテスト手法について解説します。
 
-先ほどまでのテストはコンポーネントのある部分(例: テキスト)の状態を確認するものでしたが、「スナップショットテスト」はコンポーネントの全体の状態を確かめるためのテストです。
-より正確には、コンポーネントのDOMをまるごと保存し、その保存したDOMと、テスト実行時にコンポーネントを描画して生成したDOMとが一致するかを確認します(DOMとは何かがよく分からない場合、ここではひとまず「コンポーネントを表すオブジェクト」程度に捉えてください)。
+先ほどまでのテストはコンポーネントのある部分(例: テキスト)の状態を確認するものでしたが、「スナップショットテスト」はコンポーネントの全体の状態を確かめるためのテストです。より正確には、コンポーネントのDOMをまるごと保存し、その保存したDOMと、テスト実行時にコンポーネントを描画して生成したDOMとが一致するかを確認します(DOMとは何かがよく分からない場合、ここではひとまず「コンポーネントを表すオブジェクト」程度に捉えてください)。
 
 「スナップショットテスト」は簡単に書くことができます。それでいてスタイルなど含めた全体の確認ができるので、手軽なリグレッションテストとして活用できます。一方で、そうであるからこそコンポーネントを一旦作り終えるまでは機能しないテストですので、テストファーストの開発には不向きです。
 
@@ -293,8 +319,7 @@ test("ボタンをクリックするとON/OFFの表示が切り替わる", () =>
 本来、スナップショットテストの対象はコンポーネントおよびDOMに限られたものではありません。幅広い対象にスナップショットテストが実施できます。詳しくはJestの[公式ドキュメント](https://jestjs.io/ja/docs/snapshot-testing#%E3%82%B9%E3%83%8A%E3%83%83%E3%83%97%E3%82%B7%E3%83%A7%E3%83%83%E3%83%88%E3%83%86%E3%82%B9%E3%83%88%E3%81%AFreact%E3%82%B3%E3%83%B3%E3%83%9D%E3%83%BC%E3%83%8D%E3%83%B3%E3%83%88%E3%81%A7%E3%81%AE%E3%81%BF%E5%88%A9%E7%94%A8%E3%81%A7%E3%81%8D%E3%81%BE%E3%81%99%E3%81%8B)をご参照ください。
 :::
 
-それでは、スナップショットテストを実際にやってみましょう。
-先ほどと同じ`src`ディレクトリ配下で`SimpleButton.test.tsx`というファイルを作成します。
+それでは、スナップショットテストを実際にやってみましょう。先ほどと同じ`src`ディレクトリ配下で`SimpleButton.test.tsx`というファイルを作成します。
 
 ```shell
 touch SimpleButton.test.tsx
@@ -311,8 +336,7 @@ touch SimpleButton.test.tsx
 
 ここではボタンが描画されてまだ何も操作されていない状態、つまりボタンにOFFと表示されている状態についてスナップショットテストを実施することを考えます。描画されたばかりの状態を検証したいので、描画してすぐにスナップショット照合を行えばよいことになります。
 
-この考えをもとに、実際のコードを書いてみましょう。
-コンポーネントの描画には`@testing-library/react`の`render`関数を、スナップショットの照合にはJestの`toMatchSnapshot()`関数をそれぞれ使用して次のように書くことができます。
+この考えをもとに、実際のコードを書いてみましょう。コンポーネントの描画には`@testing-library/react`の`render`関数を、スナップショットの照合にはJestの`toMatchSnapshot()`関数をそれぞれ使用して次のように書くことができます。
 
 ```tsx twoslash title="SimpleButton.test.tsx"
 // @noErrors
@@ -339,8 +363,7 @@ yarn test
 
 ![SimpleButtonコンポーネントのテストがPASSした結果画面](component-test/result_pass.png)
 
-さて、このとき`src`ディレクトリの中に`__snapshots__`というディレクトリが自動で追加されているはずです。これはJestがスナップショットテスト用のファイルを保存していくためのフォルダです。
-Jestのスナップショットテストは初回実行時にスナップショットテスト用のファイルを生成し、2回目から照合を行います。いまは初回実行だったため、ファイルとその置き場であるディレクトリが自動で生成されました。
+さて、このとき`src`ディレクトリの中に`__snapshots__`というディレクトリが自動で追加されているはずです。これはJestがスナップショットテスト用のファイルを保存していくためのフォルダです。Jestのスナップショットテストは初回実行時にスナップショットテスト用のファイルを生成し、2回目から照合を行います。いまは初回実行だったため、ファイルとその置き場であるディレクトリが自動で生成されました。
 
 ここでスナップショットテストについてもう少しだけ知るために、生成されたスナップショットテスト用のファイルの中身を覗いてみましょう。
 
@@ -360,9 +383,7 @@ exports[`描画されてすぐはOFFと表示されている 1`] = `
 
 このように、スナップショットテスト用のファイルはテストケースの名前と、そのテストケースで使われるスナップショットで構成されています。
 
-さて、今回生成されたスナップショットは`OFF`というテキストを持った`button`タグと、その親要素である`div`タグで構成されています。
-これは、まさに先ほど作った`SimpleButton`コンポーネントのDOMに一致します(`div`要素はReactの起動時に自動生成される要素です)。
-このスナップショットテストは実行のたびに、`SimpleButton`コンポーネントを描画して、たった今作られたこのスナップショットとの違いが生まれていないかを確認してくれます。
+さて、今回生成されたスナップショットは`OFF`というテキストを持った`button`タグと、その親要素である`div`タグで構成されています。これは、まさに先ほど作った`SimpleButton`コンポーネントのDOMに一致します(`div`要素はReactの起動時に自動生成される要素です)。このスナップショットテストは実行のたびに、`SimpleButton`コンポーネントを描画して、たった今作られたこのスナップショットとの違いが生まれていないかを確認してくれます。
 たとえば、もしも何かの手違いで`SimpleButton`コンポーネントが描画されたときに`ON`と表示されるようになっていたら、このスナップショットテストに引っかかるのです。
 
 ここで、実際に失敗する様子も確認してみましょう。`SimpleButton`コンポーネントが描画されたときに`ON`と表示されるよう変更を加えます。

--- a/docs/tutorials/react-like-button-tutorial.md
+++ b/docs/tutorials/react-like-button-tutorial.md
@@ -6,6 +6,8 @@
 
 Reactの専門書と比べて、本書の解説は詳しさや正確さは劣ります。それでも、初めてReactに触れる方でも読み進められるよう、Reactについて随時ワンポイント解説をしていくので、安心してお読みください。
 
+このチュートリアルで作成するいいねボタンの最終的な成果物は[デモサイト](https://like-button.typescriptbook.jp)で確認できます。チュートリアルを開始する前に事前に触ってみることで、各ステップでどんな実装をしているかのイメージが掴みやすくなります。また、完成形のソースコードは[GitHub](https://github.com/yytypescript/like-button)で確認することができます。
+
 ## Reactとは？
 
 ReactはFacebook社が開発した、ウェブアプリケーションのUIを作るためのパッケージです。JavaScriptやTypeScriptだけでもインタラクティブなUIは実装できます。しかし、UIが複雑になるとReactなしではコードの記述量が増大したり、可読性が悪くなったりと難易度が上がります。なんといっても、UIが今どのような状態なのかを管理するのは、プログラマが把握しきれない複雑さになることがあります。Reactを使うと、複雑なUIやインタラクションを短く簡潔に読みやすく書けるようになり、状態の管理も分かりやすくなります。
@@ -104,9 +106,9 @@ Reactには、小さいコンポーネントを組み合わせ、大きなアプ
 
 このチュートリアルをやるに当たって、必要なツールがあります。それらはここにリストアップしておくのであらかじめ用意しておいてください。
 
-- Node.js
+- Node.js (このチュートリアルではv18.15.0で動作確認しています)
 - NPM
-- Yarn
+- Yarn v1系 (このチュートリアルはv1.22.19で動作確認しています)
 - VS CodeやWebStormなどのエディター
 
 ## Yarnのインストール
@@ -121,29 +123,53 @@ npm install -g yarn
 
 ## プロジェクトを作る
 
-まず、`npx create-react-app`コマンドでReactプロジェクトのひながたを生成します。
+まず、`yarn create`コマンドでReactプロジェクトのひながたを生成します。
 
 ```sh
-npx create-react-app like-button --template typescript
+yarn create react-app like-button --template typescript
 ```
 
-1分ほどするとひながたの生成が完了します。like-buttonディレクトリが生成されるので、そのディレクトリに移動すると、ひながたが生成されているのが分かります。
+1分ほどするとひながたの生成が完了します。like-buttonディレクトリが生成されるので、次のコマンドを実行してそのディレクトリに移動すると、ひながたが生成されているのが分かります。
 
 ```sh
 cd ./like-button
-ls -a1
+```
 
+```text title="生成後のディレクトリ構成"
 .
-..
-.git
-.gitignore
-README.md
-node_modules
-package.json
-public
-src
-tsconfig.json
-yarn.lock
+├── .gitignore
+├── README.md
+├── package.json
+├── public
+│   ├── favicon.ico
+│   ├── index.html
+│   ├── logo192.png
+│   ├── logo512.png
+│   ├── manifest.json
+│   └── robots.txt
+├── src
+│   ├── App.css
+│   ├── App.test.tsx
+│   ├── App.tsx
+│   ├── index.css
+│   ├── index.tsx
+│   ├── logo.svg
+│   ├── react-app-env.d.ts
+│   ├── reportWebVitals.ts
+│   └── setupTests.ts
+├── tsconfig.json
+└── yarn.lock
+```
+
+create-react-appではReactのインストールも自動で行われます。インストールされたReactのバージョンを確認するには次のコマンドを用います。
+
+```sh
+yarn list react
+```
+
+```text title="yarn list reactの実行結果"
+yarn list v1.22.19
+└─ react@18.2.0
 ```
 
 このディレクトリにて`yarn start`を実行すると、Reactのローカル開発サーバーが起動します。
@@ -163,10 +189,9 @@ CtrlキーとCキーを同時に押すと、コマンドを中断することが
 
 ひながた初期状態の上のページはsrc/App.tsxの内容が描画されています。ためしに、src/App.tsxを変更してみましょう。App.tsxの`<header>`要素の中身を消して、「TypeScriptはいいぞ」に書き換えてみましょう。
 
-```tsx twoslash {8} title="App.tsx"
+```tsx twoslash {7} title="App.tsx"
 // @noErrors
 import React from "react";
-import logo from "./logo.svg";
 import "./App.css";
 
 function App() {


### PR DESCRIPTION
- docs: ✏️ 「いいねボタンを作ろう」をReact 18に対応しました。
- 「コンポーネントテストの「ボタンをクリックするとON/OFFの表示が切り替わる」がtesting-library/user-event@14でFAILになる問題を解決しました。 #689

<!--
本プロジェクトではチケット駆動を原則としています。GitHubのキーワードを用いたissueの関連付け機能を用いて、対応したissueをプルリクエストに関連付けてください。

・チケット駆動: https://typescriptbook.jp/writing/ticket-driven
・issue関連付け機能: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

close #689
close #709
