### PR TITLE
誤植「早期リ`ータ`ン」→「早期リ`ター`ン」

### DIFF
--- a/docs/reference/statements/control-flow-analysis-and-type-guard.md
+++ b/docs/reference/statements/control-flow-analysis-and-type-guard.md
@@ -57,7 +57,7 @@ function showMonth(month: string | number) {
 
 この変更によりエラーとなっていた`month`の`toFixed`メソッドの呼び出しの型エラーが解消されます。
 
-これは制御フロー分析により`month`変数が`string`型の場合は早期リータンにより関数が終了し、`month`の`toFixed`メソッドが実行されるタイミングでは`month`変数は`number`型のみであるとTypeScriptが判断するためです。
+これは制御フロー分析により`month`変数が`string`型の場合は早期リターンにより関数が終了し、`month`の`toFixed`メソッドが実行されるタイミングでは`month`変数は`number`型のみであるとTypeScriptが判断するためです。
 
 ## 型ガード
 


### PR DESCRIPTION
<!--
本プロジェクトではチケット駆動を原則としています。GitHubのキーワードを用いたissueの関連付け機能を用いて、対応したissueをプルリクエストに関連付けてください。

・チケット駆動: https://typescriptbook.jp/writing/ticket-driven
・issue関連付け機能: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

close #746
