### PR TITLE
「インデックスアクセス型」にて配列型とタプル型を分けて解説するように変更しました。

### DIFF
--- a/docs/reference/type-reuse/indexed-access-types.md
+++ b/docs/reference/type-reuse/indexed-access-types.md
@@ -65,11 +65,11 @@ type T = MixedArray[number];
 //   ^?
 ```
 
-[`typeof`型演算子](typeof-type-operator.md)と組み合わせると、[タプル型](../values-types-variables/tuple.md)の値から各要素の型を導くこともできます。
+[`typeof`型演算子](typeof-type-operator.md)と組み合わせると、配列の値から要素の型を導くこともできます。
 
 ```ts twoslash
-const stateList = ["open", "closed"] as const;
-type State = (typeof stateList)[number];
+const array = [null, "a", "b"];
+type T = (typeof array)[number];
 //   ^?
 ```
 
@@ -80,6 +80,14 @@ type State = (typeof stateList)[number];
 ```ts twoslash
 type Tuple = [string, number];
 type T = Tuple[0];
+//   ^?
+```
+
+[`typeof`型演算子](typeof-type-operator.md)と組み合わせると、タプル型の値から要素の型を導くこともできます。
+
+```ts twoslash
+const stateList = ["open", "closed"] as const;
+type State = (typeof stateList)[number];
 //   ^?
 ```
 


### PR DESCRIPTION
<!--
本プロジェクトではチケット駆動を原則としています。GitHubのキーワードを用いたissueの関連付け機能を用いて、対応したissueをプルリクエストに関連付けてください。

・チケット駆動: https://typescriptbook.jp/writing/ticket-driven
・issue関連付け機能: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

close #752
