### PR TITLE
fix:@noErrorによる@log位置ズレの修正

### DIFF
--- a/docs/reference/builtin-api/map.md
+++ b/docs/reference/builtin-api/map.md
@@ -108,11 +108,12 @@ console.log(map);
 
 ```js twoslash
 // JavaScript
-// @noErrors
+
 console.log({} == {});
 // @log: false
 console.log({} === {});
 // @log: false
+// @noErrors
 ```
 
 ```ts twoslash

--- a/docs/reference/values-types-variables/equality.md
+++ b/docs/reference/values-types-variables/equality.md
@@ -109,7 +109,6 @@ object型は、同じプロパティと値のペアの比較をしても、ま�
 
 ```js twoslash
 // JavaScript
-// @noErrors
 
 console.log({} == {});
 // @log: false
@@ -122,6 +121,7 @@ console.log({ equipment: "glasses" } === { equipment: "glasses" });
 const obj = { hair: "blond" };
 console.log(obj === obj);
 // @log: true
+// @noErrors
 ```
 
 ## まとめ


### PR DESCRIPTION
<!--
本プロジェクトではチケット駆動を原則としています。GitHubのキーワードを用いたissueの関連付け機能を用いて、対応したissueをプルリクエストに関連付けてください。

・チケット駆動: https://typescriptbook.jp/writing/ticket-driven
・issue関連付け機能: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

close #817

noErrorがあると後続のlogがズレることが分かったので、noErrorをシンタックスの末尾に移動
ズレる原因は分かっていません

### 変更前
![変更前](https://github.com/yytypescript/book/assets/49807271/80f74376-e660-43b9-8dfa-1ca9a82efef3)

### 変更後
![変更後](https://github.com/yytypescript/book/assets/49807271/a6fd8974-f6e0-4b6f-84cc-b41c189e222e)

