### PR TITLE
RecordとMapped Typesのインデックスアクセスの解説を改善しました。

### DIFF
--- a/docs/reference/type-reuse/utility-types/record.md
+++ b/docs/reference/type-reuse/utility-types/record.md
@@ -35,6 +35,74 @@ const person: Person = {
 };
 ```
 
+## インデックスアクセスの注意点
+
+`Record<string, ...>`のようにキーに`string`など、リテラル型でない型を指定した場合は、インデックスアクセスに注意してください。存在しないキーにアクセスしても、キーが必ずあるかのようにあつかわれるためです。
+
+次の例のように、`Record<string, number>`型の`dict`オブジェクトには、`a`キーはあるのに対し、`b`キーはありません。しかし、`dict.b`は`number`として推論されます。
+
+```ts twoslash
+// @noUncheckedIndexedAccess: false
+const dict: Record<string, number> = { a: 1 };
+dict.b;
+//   ^?
+```
+
+実際の`dict.b`の値は`undefined`になるので、もしも`dict.b`のメソッドを呼び出すと実行時エラーになります。
+
+```ts twoslash
+const dict: Record<string, number> = { a: 1 };
+console.log(dict.b);
+// @log: undefined
+dict.b.toFixed(); // 実行時エラーが発生する
+// @noUncheckedIndexedAccess: false
+```
+
+このような挙動は、型チェックで実行時エラーを減らしたいと考える開発者にとっては不都合です。
+
+この問題に対処するため、TypeScriptにはコンパイラオプション`noUncheckedIndexedAccess`が用意されています。これを有効にすると、インデックスアクセスの結果の型が`T | undefined`になります。つまり、`undefined`の可能性を考慮した型になるわけです。そのため、`dict.b`のメソッドを呼び出すコードはコンパイルエラーになり、型チェックの恩恵が得られます。
+
+```ts twoslash
+// @errors: 18048
+// @noUncheckedIndexedAccess: true
+const dict: Record<string, number> = { a: 1 };
+dict.b;
+//   ^?
+dict.b.toFixed();
+```
+
+[noUncheckedIndexedAccess](../../tsconfig/nouncheckedindexedaccess.md)
+
+一方、`Record`のキーが`"firstName" | "lastName"`のようなリテラル型だけで構成される場合は、`noUncheckedIndexedAccess`の設定にかかわらず、この問題は発生しません。キーが限定されているため、存在しないキーへのアクセスはコンパイルエラーになるからです。
+
+```ts twoslash
+// @noUncheckedIndexedAccess: false
+// @errors: 2339
+// noUncheckedIndexedAccessがfalseの場合
+type Person = Record<"firstName" | "lastName", string>;
+const person: Person = {
+  firstName: "Robert",
+  lastName: "Martin",
+};
+const firstName = person.firstName;
+//    ^?
+person.b; // 存在しないキーへのアクセス
+```
+
+キーが`string`のときは`noUncheckedIndexedAccess`を有効にすると、コンパイラーは`undefined`を含めるようになりますが、キーがリテラル型(またはリテラル型のユニオン)のときは、コンパイラーは`undefined`を含めないようになります。キーが必ずあることが、リテラル型によるキー指定によって自明だからです。
+
+```ts twoslash
+// @noUncheckedIndexedAccess: true
+// noUncheckedIndexedAccessがtrueの場合
+type Person = Record<"firstName" | "lastName", string>;
+const person: Person = {
+  firstName: "Robert",
+  lastName: "Martin",
+};
+const firstName = person.firstName; // undefinedは含まれない
+//    ^?
+```
+
 ## 関連情報
 
 [インデックス型 (index signature)](../../values-types-variables/object/index-signature.md)


### PR DESCRIPTION
Record<string, T>や{ [K in string]: T }のような型で、存在しないキーにアクセスした場合の挙動について、読者がより深く理解できるよう解説を修正しました。

主な変更点:
- `noUncheckedIndexedAccess: false`のとき、存在しないキーへのアクセスが実行時エラーにつながる過程をコードで明示
- `noUncheckedIndexedAccess: true`を有効にすると、型が `T | undefined` となりコンパイル時に問題を検知できることを明確化
- `Record`において、キーがリテラル型の場合は上記の問題が発生しない理由を、サンプルコードを交えて詳しく解説

<!--
本プロジェクトではチケット駆動を原則としています。GitHubのキーワードを用いたissueの関連付け機能を用いて、対応したissueをプルリクエストに関連付けてください。

・チケット駆動: https://typescriptbook.jp/writing/ticket-driven
・issue関連付け機能: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

close #1007
