### PR TITLE
docs: keyof型演算子の返り値説明を明確化しました。

### DIFF
--- a/docs/reference/type-reuse/keyof-type-operator.md
+++ b/docs/reference/type-reuse/keyof-type-operator.md
@@ -10,18 +10,18 @@ type PersonKey = keyof Person;
 //    ^?
 ```
 
-2つ以上のプロパティがあるオブジェクトの型に`keyof`を使った場合は、すべてのプロパティ名がユニオン型で返されます。
+2つ以上のプロパティがあるオブジェクトの型に`keyof`を使うと、各プロパティ名の文字列リテラル型が`|`で結合されたユニオン型が返されます。
 
 ```ts twoslash
-// @noErrors
 type Book = {
   title: string;
   price: number;
   rating: number;
 };
 type BookKey = keyof Book;
+//   ^?
 // 上は次と同じ意味になる
-type BookKey = "title" | "price" | "rating";
+// type BookKey = "title" | "price" | "rating";
 ```
 
 インデックス型に`keyof`を使うと、インデックスキーの型が返ります。


### PR DESCRIPTION
- 説明文を「各プロパティ名の文字列リテラル型が `|` で結合されたユニオン型が返される」に修正
- 例示は twoslash の型ヒント（`^?`）で示す形に変更し、明示的な `"title" | "price" | "rating"` の代入例はコメントアウト
- `@noErrors` を削除して例を簡潔化

背景 / 変更理由:
- Issue #957 の議論で、“union” を「和集合」と解すべきという指摘があったが、TypeScript では `"a" | "b"` をユニオン型と呼ぶことが公式・一般に定着しているため、本書でも「ユニオン型」に用語を統一
- 公式ドキュメントでの表現も “literal union of its keys” であり、集合論用語（和集合）をこのページのみで用いると書籍全体の用語一貫性が崩れ、初学者の混乱につながる可能性がある
- 「和集合」は値の集合を連想させ、値と型の二重性（リテラルが値であり型でもある）を学ぶ局面で誤解を招きやすいため、`|` で連結されるユニオン型という具体的説明で補足して明確化

Close #957
