### PR TITLE
誤植を修正しました: 「JavaScriptの」→「JavaScriptも」

### DIFF
--- a/docs/tutorials/eslint.md
+++ b/docs/tutorials/eslint.md
@@ -933,7 +933,7 @@ module.exports = {
 
 `parser`で設定したパーサーを使って、ESLintはJavaScriptやTypeScriptの構文を解析します。上の例では、TypeScriptパーサーを指定しています。この指定がないと、ESLintはTypeScriptを解釈できず、エラーが発生します。
 
-TypeScriptはJavaScriptの構文を拡張した言語です。なので、このパーサーさえ入れておけば、TypeScriptに限らずJavaScriptのこのパーサーひとつで対応できます。要するに、このパーサーひとつで、TypeScriptとJavaScriptのファイルどちらもリントできるようになります。
+TypeScriptはJavaScriptの構文を拡張した言語です。なので、このパーサーさえ入れておけば、TypeScriptに限らずJavaScriptもこのパーサーひとつで対応できます。要するに、このパーサーひとつで、TypeScriptとJavaScriptのファイルどちらもリントできるようになります。
 
 #### `plugins`
 


### PR DESCRIPTION
Closes #963

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes wording in `docs/tutorials/eslint.md` to clarify the TypeScript parser can lint JavaScript as well.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50e539a5a7d58a5dcbc42fca6e1259edab5a548f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->