### PR TITLE
interfaceとtypeの違いに「インデックス型への代入互換性」の解説を追加しました。

### DIFF
--- a/docs/reference/values-types-variables/object/index-signature.md
+++ b/docs/reference/values-types-variables/object/index-signature.md
@@ -51,3 +51,5 @@ let obj2: Record<string, number>;
 ## 関連情報
 
 [Mapped Types](../../type-reuse/mapped-types.md)
+
+[interfaceとtypeの違い](../../object-oriented/interface/interface-vs-type-alias.md)


### PR DESCRIPTION
## 概要

interfaceとtypeにはインデックス型への代入互換性に違いがあります。
この違いがわからないと「なぜか代入できない！」とハマりやすいため、
解説を追加しました。

## 変更内容

- 比較表に「インデックス型への代入互換性」行を追加
- 新しいセクション「インデックス型への代入互換性」を追加
  - 基本的な例（PersonInterface / PersonType）
  - 実際のユースケース（Record<string, T>を使う場面）
  - 回避策（スプレッド構文、Pick、明示的追加）
- インデックス型ページに相互参照を追加

Close #868

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances documentation on interface vs type alias differences.
> 
> - Adds a new section on `インデックス型への代入互換性` with examples (`PersonInterface`/`PersonType`), `Record<string, T>` use case, and workarounds (spread, `Pick`, explicit index signature)
> - Updates the comparison table to include the new compatibility row
> - Adds a related link from `index-signature.md` to the interface vs type page
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 036e7d01c1343e8c84336e4f8bfb2f08fdada380. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->