### PR TITLE
本文の`text-align: justify`を削除しました

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -41,7 +41,6 @@
 }
 
 .markdown p {
-  text-align: justify;
   word-wrap: break-word;
   letter-spacing: 0.01rem;
 }


### PR DESCRIPTION
## 概要

スマートフォンなど狭い画面で閲覧した際に、両端揃え（`text-align: justify`）によって文字間に不自然なスペース（リバー現象）が発生し、読みづらくなる問題を修正しました。

## 変更内容

- `src/css/custom.css` の `.markdown p` から `text-align: justify` を削除

## 確認結果

- 変更前: `text-align: justify` → 文字間にスペースが発生
- 変更後: `text-align: start` → 自然なテキストの流れに

Close #782

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - Removes `text-align: justify` from `.markdown p` in `src/css/custom.css`, preventing uneven spacing on small screens and restoring default paragraph alignment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3193490d85968de9b37c8c401104e5a28e61142a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->