### PR TITLE
コードブロックの言語指定ガイドラインを追加しました

### DIFF
--- a/docs/writing/markdown.md
+++ b/docs/writing/markdown.md
@@ -118,6 +118,52 @@ Markdownのリンクテキストは無視され、リンク先のタイトルが
 
 - https://github.com/shikijs/shiki/blob/main/docs/languages.md#all-languages
 
+### コードブロックの言語指定
+
+コードブロックは**常に`ts twoslash`を使用**します。twoslashを指定すると、ビルド時にTypeScriptコンパイラによるエラーチェックが行われ、サンプルコードの品質を保てます。
+
+````markdown
+```ts twoslash
+const message = "Hello";
+console.log(message);
+```
+````
+
+JavaScriptのコードであっても`ts twoslash`を使用します。
+
+#### TypeScriptでコンパイルエラーになる場合
+
+JavaScriptとしては正しいが、TypeScriptとしてはコンパイルエラーになるコードには`@noErrors`を指定します。
+
+````markdown
+```ts twoslash
+// @noErrors
+function greet(name) {
+  console.log("Hello, " + name);
+}
+```
+````
+
+#### 最終手段としてのjs指定
+
+`@noErrors`でも回避できない構文エラーなどの場合に限り、最終手段として`js`を使用できます。
+
+````markdown
+```js
+// @noErrorsでも対応できない場合のみ使用
+```
+````
+
+:::tip まとめ
+
+| 状況                                    | 対応                          |
+| --------------------------------------- | ----------------------------- |
+| 通常のコード（TSでもJSでも）            | `ts twoslash`を使う           |
+| TSでコンパイルエラーになるJSコード      | `ts twoslash`＋`// @noErrors` |
+| `@noErrors`でも回避できない構文エラー等 | `js`を使う（最終手段）        |
+
+:::
+
 ### コードブロックのタイトル
 
 コードブロックにタイトルをつけるには`title`属性を指定します。


### PR DESCRIPTION
## 概要

コードブロックの言語指定について、執筆者向けガイドラインを`docs/writing/markdown.md`に追加しました。

## 変更内容

- コードブロックは常に`ts twoslash`を使用することを明記
- TypeScriptでコンパイルエラーになるJSコードには`// @noErrors`を使用
- `@noErrors`でも回避できない場合に限り`js`を使用（最終手段）

## 背景

#733 の対応中に、JSコードのコードブロックを`js`とするか`ts`とするかが話題になりました。twoslashを使うとビルド時にTypeScriptコンパイラによるエラーチェックが行われ、サンプルコードの品質を保てるため、基本的に`ts twoslash`を使う方針としました。

Close #755

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds authoring guidelines for code block language selection in `docs/writing/markdown.md`.
> 
> - Introduces `コードブロックの言語指定` section mandating `ts twoslash` for all code samples (including JS) to enable TS compile-time checks
> - Documents using `// @noErrors` for JS-valid but TS-erroring snippets, and allowing `js` only as a last resort when errors can't be avoided
> - Provides concise examples and a tip summary table outlining the decision flow
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ba9ef1ecc190e1c8304f8a0353deaf96615210c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->