### PR TITLE
Prettierのチュートリアルで // prettier-ignore コメントが表示されるよう修正

### DIFF
--- a/docs/tutorials/prettier.md
+++ b/docs/tutorials/prettier.md
@@ -286,7 +286,8 @@ Prettierをプロジェクトに導入する時に整形ルールについて悩
 
 `prettier-ignore`をコメントとして記述することで、一部のコードをPrettierの自動整形の対象から除外することができます。
 
-```ts twoslash title="src/hello-world.ts"
+<!--prettier-ignore-->
+```ts title="src/hello-world.ts"
 const board1 = [1, 0, 0, 1];
 
 // prettier-ignore


### PR DESCRIPTION
## 背景

「Prettierの自動整形を無効にする」セクションで、`// prettier-ignore` の使い方を説明するコードブロックにおいて、肝心の `// prettier-ignore` コメント自体がブラウザで表示されていなかった。

これは `@typescript/twoslash` パッケージが `// prettier-ignore` コメントをデフォルトで削除する仕様によるもの。

## 対応

- コードブロックから `twoslash` を削除
- Prettierによる自動整形を防ぐため `<!--prettier-ignore-->` を追加

Closes #1062

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes the Prettier tutorial so the `// prettier-ignore` example renders correctly.
> 
> - Removes `twoslash` from the example code block in `prettier.md`
> - Adds an HTML prettier-ignore comment before the block to prevent auto-formatting, ensuring `// prettier-ignore` is shown
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1cca2d55f76abe41bcaf36ebc63d3b9c16ab51af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->