### PR TITLE
「型ガード関数」のサンプルコードから `declare` を除去しました。

### DIFF
--- a/docs/reference/functions/type-guard-functions.md
+++ b/docs/reference/functions/type-guard-functions.md
@@ -96,24 +96,24 @@ function notTypeGuard(x: unknown): boolean {
   return typeof x === "number";
 }
 
-declare const input: number | string;
+function example(input: number | string) {
+  // 型の絞り込みができる
+  if (typeGuard(input)) {
+    input;
+    // ^?
+  } else {
+    input;
+    // ^?
+  }
 
-// 型の絞り込みができる
-if (typeGuard(input)) {
-  input;
-  // ^?
-} else {
-  input;
-  // ^?
-}
-
-// 型の絞り込みができない
-if (notTypeGuard(input)) {
-  input;
-  // ^?
-} else {
-  input;
-  // ^?
+  // 型の絞り込みができない
+  if (notTypeGuard(input)) {
+    input;
+    // ^?
+  } else {
+    input;
+    // ^?
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary
- 「型ガード関数」ページのコード例で使っていた `declare const input: number | string;` をやめました。
- 初期値による推論の影響を避けるため、`input: number | string` を関数引数として受け取る形に変更しました。
- これにより、初心者が `declare` に未遭遇でもコード例を読み進められます。

## Test plan
- [x] `task check`

Close #1068

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the type guard docs example to avoid `declare` and show narrowing within a scoped `function example(input: number | string)`.
> 
> - Replaces `declare const input: number | string;` with an `example` function that takes `input: number | string`
> - Keeps demonstrations of `typeGuard` vs `notTypeGuard` narrowing behavior unchanged, now scoped inside `example`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcb26a7c5b583d80a417f766181c6a678a1abec7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->