### PR TITLE
PageRefカードと前後要素との余白が適切に表示されるよう修正しました。

### DIFF
--- a/src/components/pageRef/pageRef.tsx
+++ b/src/components/pageRef/pageRef.tsx
@@ -10,14 +10,16 @@ const PageRef: FC<Props> = ({ link, title }) => {
   try {
     const { metadata } = require("@site/docs" + link.replace(/^\/+/, "/"));
     return (
-      <DocCard
-        item={{
-          type: "link",
-          href: metadata.permalink,
-          label: metadata.frontMatter.sidebar_label ?? metadata.title,
-          docId: metadata.id,
-        }}
-      />
+      <div className="book-pageRef">
+        <DocCard
+          item={{
+            type: "link",
+            href: metadata.permalink,
+            label: metadata.frontMatter.sidebar_label ?? metadata.title,
+            docId: metadata.id,
+          }}
+        />
+      </div>
     );
   } catch (e) {
     console.error(e);

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -234,6 +234,11 @@ pre .logger.log-log svg {
   text-transform: unset !important;
 }
 
+/* PageRefコンポーネントの余白（段落相当） */
+.book-pageRef {
+  margin-bottom: var(--ifm-paragraph-margin-bottom);
+}
+
 /* Custom terminal styling */
 .taml-outer {
   background: #1e1e2e;


### PR DESCRIPTION
## 対象者

- [x] 📖 読者

## Problem

`PageRef`コンポーネントで生成される`DocCard`が、前後の要素（admonition等）と密着して表示されていました。

これは `pageRefRemark.js` がMarkdownの「リンクだけの段落」を`<PageRef />`コンポーネントに置換する際に、元の`<p>`タグが持っていた`margin-bottom`が失われるためでした。

**再現ページ:** `/reference/functions/destructuring-assignment-parameters`
- 「Shorthand property names」カード直後の「学びをシェアする」admonitionとの間に余白がない

## Solution

`PageRef`コンポーネントの戻り値を`<div className="book-pageRef">`でラップし、CSSで段落相当の余白を追加しました。

- `src/components/pageRef/pageRef.tsx`: `DocCard`を`div`でラップ
- `src/css/custom.css`: `.book-pageRef`に`margin-bottom: var(--ifm-paragraph-margin-bottom)`を追加

<img width="1256" height="1790" alt="pageref-margin-fixed" src="https://github.com/user-attachments/assets/9cec661e-bfa3-4728-b1d3-8431062e224d" />


## Value

読者がカード形式のページリンクと周囲の要素との間に適切な余白を確認でき、読みやすいレイアウトで閲覧できるようになります。



---

Close #1072

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures paragraph-equivalent spacing for `PageRef` cards so they don’t butt against adjacent elements.
> 
> - Wraps `DocCard` in `PageRef` with a `div` (`book-pageRef`) to restore block-level layout (`src/components/pageRef/pageRef.tsx`)
> - Adds `.book-pageRef { margin-bottom: var(--ifm-paragraph-margin-bottom) }` to apply spacing consistently (`src/css/custom.css`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33096f18b45f8e6b6eca942f8ede33c4ab26a145. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->