### PR TITLE
npmのmin-release-age対応に合わせてセキュリティページを修正しました。

### DIFF
--- a/docs/reference/packages/package-security.md
+++ b/docs/reference/packages/package-security.md
@@ -198,7 +198,7 @@ npm uninstall 不要なパッケージ名
 - pnpm: v10.16以降で対応。`pnpm-workspace.yaml`の`minimumReleaseAge`で分単位の設定が可能です。デフォルトは無効です。
 - Bun: v1.3以降で対応。`bunfig.toml`の`minimumReleaseAge`で秒単位の設定が可能です。デフォルトは無効です。
 - Yarn Berry: v4.10以降で対応。`.yarnrc.yml`の`npmMinimalAgeGate`で期間を文字列で指定します。デフォルトは`3d`(3日間)で、唯一デフォルトで有効です。
-- npm: 未対応です。
+- npm: v11.10.0以降で対応。`.npmrc`の`min-release-age`で日数を指定します。デフォルトは無効です。
 
 関心のある方は、各パッケージマネージャーのドキュメントを確認してみてください。
 


### PR DESCRIPTION
## 対象者

- [x] 📖 読者

## Problem

「パッケージのセキュリティ」ページのminimumReleaseAgeコラムに「npm: 未対応です。」と記載されていました。しかし、npm CLI v11.10.0（2026-02-11リリース）で`min-release-age`が追加されたため、この記述は事実と異なる状態になっていました。

## Solution

npmの記述を「v11.10.0以降で対応。`.npmrc`の`min-release-age`で日数を指定します。デフォルトは無効です。」に更新しました。

## Value

読者がnpmのminimumReleaseAge対応状況を正しく把握できるようになります。

---

Close #1092