### PR TITLE
Next.jsチュートリアルのファイル構成にAGENTS.mdとCLAUDE.mdを追加しました。

### DIFF
--- a/docs/tutorials/nextjs.md
+++ b/docs/tutorials/nextjs.md
@@ -120,6 +120,8 @@ cd random-cat
 ├── node_modules/
 ├── public/
 ├── .gitignore
+├── AGENTS.md
+├── CLAUDE.md
 ├── eslint.config.mjs
 ├── .next/
 ├── next-env.d.ts


### PR DESCRIPTION
## 対象者

- [x] 📖 読者

## Problem

`npm create next-app@latest` で生成されるプロジェクトに `AGENTS.md` と `CLAUDE.md` が含まれるようになり（Next.js 16.2.3時点）、チュートリアルに記載されているファイル構成と実際の構成が一致しなくなっていました。読者がチュートリアル通りに進めた際に、ファイル構成の確認で混乱する可能性がありました。

## Solution

`docs/tutorials/nextjs.md` のファイル構成ツリーに `AGENTS.md` と `CLAUDE.md` を追加しました。

## Value

読者が `create-next-app` 実行後のファイル構成を確認する際に、チュートリアルの記述と実際のファイル構成が一致するようになります。

---

Close #1100