### PR TITLE
Vitestチュートリアルの旧MDNリンクを修正しました。

### DIFF
--- a/docs/tutorials/vitest-component-test.md
+++ b/docs/tutorials/vitest-component-test.md
@@ -226,7 +226,7 @@ test("ボタンを表示したときのカウントが999であること", async
 
 次は状態確認です。`999`と表示されていることを確かめます。具体的には、ボタンを取得し、そのテキストが`999`という文字列に等しいかのアサーションを実施します。
 
-今回、ボタンの取得には`getByRole`を使います。これは[WAI-ARIA](https://developer.mozilla.org/ja/docs/Learn/Accessibility/WAI-ARIA_basics)(アクセシビリティ向上を主目的として定められたwebの仕様)で定められたロールを引数に指定すると、そのロールを持つ要素を取得するクエリです。具体的には、次のように書けます。詳細は[Locator](https://main.vitest.dev/api/browser/locators)をご参照ください。
+今回、ボタンの取得には`getByRole`を使います。これは[WAI-ARIA](https://developer.mozilla.org/ja/docs/Learn_web_development/Core/Accessibility/WAI-ARIA_basics)(アクセシビリティ向上を主目的として定められたwebの仕様)で定められたロールを引数に指定すると、そのロールを持つ要素を取得するクエリです。具体的には、次のように書けます。詳細は[Locator](https://main.vitest.dev/api/browser/locators)をご参照ください。
 
 <!-- regression test: 上の段落に含まれる全てのリンク先が正しいことを確認してください。 -->
 


### PR DESCRIPTION
## 対象者

- [x] 📖 読者

## Problem

「Reactコンポーネントのテストを書こう」チュートリアル内のMDN WAI-ARIAリンクが、MDNのドキュメント構造再編により旧URLになっていました。アクセスすると301リダイレクトで正しいページに転送されますが、URLが最新ではない状態でした。

- 旧: `https://developer.mozilla.org/ja/docs/Learn/Accessibility/WAI-ARIA_basics`
- 新: `https://developer.mozilla.org/ja/docs/Learn_web_development/Core/Accessibility/WAI-ARIA_basics`

## Solution

`docs/tutorials/vitest-component-test.md` のWAI-ARIAリンクを新しいURLに更新しました。

## Value

読者がリンクをクリックした際にリダイレクトを経由せず、直接MDNの正しいページにアクセスできるようになります。

---

Close #1102