### PR TITLE
Prettierチュートリアルの公式ドキュメントURLを修正しました。

### DIFF
--- a/docs/tutorials/prettier.md
+++ b/docs/tutorials/prettier.md
@@ -163,7 +163,7 @@ const hello = (name: string) => {
 Prettierはデフォルトの整形ルールが定義されています。先ほどの実行結果を見るとインデントが幅2つのスペースでインデントがされているのが分かります。
 
 代表的な項目のデフォルト値は次のようになっています。
-すべての項目のデフォルト値を確認したい場合は、[Prettierの公式ドキュメント](https://prettier.io/docs/en/options.html)を参照してください。
+すべての項目のデフォルト値を確認したい場合は、[Prettierの公式ドキュメント](https://prettier.io/docs/options)を参照してください。
 
 <!-- regression test: 上記のリンクが正しいか確認してください。 -->
 
@@ -295,7 +295,7 @@ Prettierの他にも、VSCodeは[プラグイン](https://marketplace.visualstud
 ### 他の整形ルールを確認する
 
 ここで紹介した以外にもいくつかの整形ルールが存在します。
-他の整形ルールやCLIコマンドのオプション名、設定ファイルのキー名などを確認したい場合は[Prettierの公式ドキュメント](https://prettier.io/docs/en/options.html)をご参照ください。
+他の整形ルールやCLIコマンドのオプション名、設定ファイルのキー名などを確認したい場合は[Prettierの公式ドキュメント](https://prettier.io/docs/options)をご参照ください。
 
 <!-- regression test: 上記のリンクが正しいか確認してください -->
 


### PR DESCRIPTION
## 対象者

- [x] 📖 読者

## Problem

Prettierチュートリアル内の公式ドキュメントへのリンク（2箇所）が旧パス `https://prettier.io/docs/en/options.html` のままになっていました。このURLは301リダイレクトで新URLに転送されるため閲覧自体は可能でしたが、リダイレクトを挟む分だけ読者の体験が低下していました。

## Solution

`docs/tutorials/prettier.md` 内の2箇所のURLを新パスに更新しました。

- `https://prettier.io/docs/en/options.html` → `https://prettier.io/docs/options`

## Value

読者がPrettier公式ドキュメントへリダイレクトなしで直接アクセスできるようになります。

---

Close #1103