### PR TITLE
リリースノート2026-05-15を作成しました。

### DIFF
--- a/docs/releasenotes/2026-05-15.md
+++ b/docs/releasenotes/2026-05-15.md
@@ -1,0 +1,51 @@
+---
+date: 2026-05-15
+---
+
+# 2026-05-15 「using宣言」ページを新規追加、Node.js v26対応など
+
+2026年5月15日の更新内容をお届けします。
+
+## ✨ ハイライト
+
+### 「using宣言」の解説ページを新規追加しました
+
+「読んで学ぶTypeScript」リファレンスの「値・型・変数」カテゴリに、新ページ「using宣言」を追加しました。TypeScript 5.2から導入された`using`宣言と`await using`宣言は、ファイルハンドルやデータベース接続などのリソースをスコープ脱出時に確実に解放するための機能ですが、これまで本書には体系的な解説がありませんでした。
+
+新ページでは、リソースとリソースリークの基本から、Denoのファイル APIを使った手動クリーンアップと`using`宣言の比較、`Disposable`と`Symbol.dispose`、`await using`と`AsyncDisposable`、`Symbol.asyncDispose`まで丁寧に解説しています。さらに、C#の`using`句やRustの`Drop`トレイトといった他言語のRAIIパターンとの比較も交え、TypeScriptにおける明示的なリソース管理の位置づけが立体的にわかる構成にしています。（[#1057] by [@yo-goto]）
+
+[using宣言](../reference/values-types-variables/using.md)
+
+### チュートリアルをNode.js v26に対応しました
+
+Node.js v26が新たなアクティブLTSとなったことを受けて、本書の各チュートリアルの前提条件を「Node.js v24以上」から「v26以上」に更新しました。「開発環境の準備」のHomebrewインストール手順も`brew install node@26`に切り替えています。最新の安定版を使って、安心して学習を進められます。（[#1116] by [@suin]）
+
+### 修正・改善
+
+- [開発環境の準備](../tutorials/setup.md) - `tsc -v`の出力例をTypeScript 6.0.3に更新しました（[#1112] by [@suin]）
+- [ESLintチュートリアル](../tutorials/eslint.md) - 出力例の`(0 error, 2 warnings)`を実際のESLint出力に合わせて`(0 errors, 2 warnings)`に修正しました（[#1116] by [@suin]）
+- [Vitestチュートリアル](../tutorials/vitest.md) - `vitest run`の出力例をVitest 4.1.5の現在の挙動に合わせて更新しました（[#1116] by [@suin]）
+- [Vitestでコンポーネントをテストする](../tutorials/vitest-component-test.md) - 「ファイルこに」というタイポを「ファイルに」に修正しました（[#1116] by [@suin]）
+
+## 👥 コントリビューター
+
+今回のアップデートに貢献してくださった方々です。ありがとうございます！
+
+- [@yo-goto]
+- [@suin]
+
+---
+
+いつもサバイバルTypeScriptをご利用いただきありがとうございます。
+ご意見・ご要望は [GitHub Issues](https://github.com/yytypescript/book/issues) までお寄せください。
+
+<!-- PR参照リンク -->
+
+[#1057]: https://github.com/yytypescript/book/pull/1057
+[#1112]: https://github.com/yytypescript/book/pull/1112
+[#1116]: https://github.com/yytypescript/book/pull/1116
+
+<!-- コントリビューター参照リンク -->
+
+[@yo-goto]: https://github.com/yo-goto
+[@suin]: https://github.com/suin


### PR DESCRIPTION
## 対象者

- [x] 📖 読者

## Problem

前回のリリース（2026-04-17）以降にいくつかのコンテンツ更新がありましたが、変更内容をまとめたリリースノートがまだ公開されていませんでした。読者は何が新しく追加・改善されたかを把握しづらく、新規ページや更新内容にたどり着く導線がない状態でした。

## Solution

`docs/releasenotes/2026-05-15.md` を新規追加しました。

- ✨ ハイライト
  - 「using宣言」の解説ページを新規追加（[#1057]）
  - チュートリアルをNode.js v26に対応（[#1116]）
- 修正・改善
  - `setup.md` の `tsc -v` 出力例をTypeScript 6.0.3に更新（[#1112]）
  - ESLintチュートリアルの出力例タイポ修正（[#1116]）
  - Vitestチュートリアルの `vitest run` 出力例を最新挙動に合わせて更新（[#1116]）
  - Vitestコンポーネントテストの「ファイルこに」タイポ修正（[#1116]）
- 👥 コントリビューター: [@yo-goto]、[@suin]

## Value

読者が前回リリース以降の更新を一覧で把握でき、興味のあるトピック（特に新規追加の「using宣言」ページ）へスムーズに到達できるようになります。

---

Close #1121

[#1057]: https://github.com/yytypescript/book/pull/1057
[#1112]: https://github.com/yytypescript/book/pull/1112
[#1116]: https://github.com/yytypescript/book/pull/1116
[@suin]: https://github.com/suin
[@yo-goto]: https://github.com/yo-goto