### PR TITLE
変性の説明と型定義の対応を修正しました。

### DIFF
--- a/docs/reference/generics/variance.md
+++ b/docs/reference/generics/variance.md
@@ -33,7 +33,7 @@ TypeScriptでは、型の互換性を判定する際に変性(variance)という
 type BivariantFunction<I, O> = (arg: I) => O;
 ```
 
-ここで引数`I`を共変にした`CovariantFunction<in I, O>`と戻り値`O`を反変にした`ContravariantFunction<I, out O>`、引数も戻り値も不変にした`InvariantFunction<in out I, in out O>`を定義します。するとそれらは次のように定義されます。
+ここで戻り値`O`を共変にした`CovariantFunction<I, out O>`と引数`I`を反変にした`ContravariantFunction<in I, O>`、引数も戻り値も不変にした`InvariantFunction<in out I, in out O>`を定義します。するとそれらは次のように定義されます。
 
 ```ts twoslash
 type BivariantFunction<I, O> = (arg: I) => O;


### PR DESCRIPTION
## 対象者

- [x] 📖 読者

## Problem

変性の説明では引数`I`を共変、戻り値`O`を反変としていました。一方で直後の型定義では、戻り値`O`に`out`、引数`I`に`in`を指定していました。説明とコード例が逆になっており、読者が変性を誤って理解する可能性がありました。

## Solution

`CovariantFunction<I, out O>`と`ContravariantFunction<in I, O>`の型定義に合わせて、戻り値`O`が共変、引数`I`が反変であることを説明しました。

## Value

読者が`out`による共変性と`in`による反変性を、コード例と対応付けて理解できるようになります。

---

close #1137