### PR TITLE
ReturnTypeの偶数判定例を修正しました。

### DIFF
--- a/docs/reference/type-reuse/utility-types/return-type.md
+++ b/docs/reference/type-reuse/utility-types/return-type.md
@@ -27,7 +27,7 @@ type ReturnType3 = ReturnType<() => never>;
 
 ```ts twoslash
 const isEven = (num: number) => {
-  return num / 2 === 0;
+  return num % 2 === 0;
 };
 
 type isEvenRetType = ReturnType<typeof isEven>;


### PR DESCRIPTION
## 対象者

- [x] 📖 読者

## Problem

`ReturnType<T>`のページにある`isEven`のコード例では、偶数判定に除算演算子を使用していました。この式は0以外の偶数を`false`と判定するため、関数名と動作が一致していませんでした。

## Solution

偶数判定の演算子を除算から剰余へ変更し、`num % 2 === 0`で判定するように修正しました。

## Value

読者がコード例をそのまま実行しても、偶数判定として正しい動作を確認できるようになります。

---

close #1135