### PR TITLE
MapとSetのsize見出しを修正しました。

### DIFF
--- a/docs/reference/builtin-api/map.md
+++ b/docs/reference/builtin-api/map.md
@@ -234,7 +234,7 @@ if (typeof n === "number") {
 
 :::
 
-### 要素の個数を取得する - `Map.prototype.size()`
+### 要素の個数を取得する - `Map.prototype.size`
 
 `Map`に登録されている要素数を調べるには`size`フィールドの値を見ます。
 

--- a/docs/reference/builtin-api/set.md
+++ b/docs/reference/builtin-api/set.md
@@ -94,7 +94,7 @@ console.log(numbers.has(999));
 // @log: false
 ```
 
-### 値の個数を取得する - `Set.prototype.size()`
+### 値の個数を取得する - `Set.prototype.size`
 
 `Set`にいくつ値が登録されているかを調べるには、`size`フィールドの値を見ます。
 


### PR DESCRIPTION
## 対象者

- [x] 📖 読者

## Problem

MapとSetの要素数を説明する見出しでは、`size()`をメソッドとして表記していました。しかし、本文とコード例では`size`プロパティを使用しており、見出しと実際のAPIが一致していませんでした。

## Solution

MapとSetの見出しを、それぞれ`Map.prototype.size`と`Set.prototype.size`に修正しました。

## Value

読者が`size`をプロパティとして正しく使用でき、呼び出し時のエラーを避けられるようになります。

---

close #1134