### PR TITLE
Options Objectの説明文を修正しました。

### DIFF
--- a/docs/reference/functions/keyword-arguments-and-options-object-pattern.md
+++ b/docs/reference/functions/keyword-arguments-and-options-object-pattern.md
@@ -270,7 +270,7 @@ func({ x: 1, y: undefined });
 
 ## Option Object自体をオプショナルにする方法
 
-TypeScriptでOptions Object自体を渡さなくても関数を呼び出せるようにするには、Options Objectのデフォルト値として空のオブジェクト`{}`を指定するとできます。
+TypeScriptでOptions Object自体を渡さずに関数を呼び出せるようにするには、Options Objectのデフォルト値に空のオブジェクト`{}`を指定します。
 
 ```ts twoslash
 type Options = {


### PR DESCRIPTION
## 対象者

- [x] 📖 読者

## Problem

Options Object自体を省略する方法の説明に、不自然な「指定するとできます」という表現がありました。文意は推測できますが、初学者が読み進める際の妨げになる可能性がありました。

## Solution

空のオブジェクトをOptions Objectのデフォルト値に指定する方法を、簡潔で自然な文に修正しました。

## Value

読者がOptions Object自体を省略可能にする方法を、迷わず理解できるようになります。

---

close #1132